### PR TITLE
Add initial EF Core migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+bin/
+obj/
+*.user
+*.suo
+*.swp
+.vs/
+**/bin/
+**/obj/
+/.idea/
+*.db

--- a/Mazad.sln
+++ b/Mazad.sln
@@ -1,0 +1,39 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mazad.Domain", "src\Mazad.Domain\Mazad.Domain.csproj", "{A5031680-7DF8-4EAE-A698-05A593169CAA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mazad.Application", "src\Mazad.Application\Mazad.Application.csproj", "{EF789967-F231-466D-93EA-D5BF3E62709C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mazad.Infrastructure", "src\Mazad.Infrastructure\Mazad.Infrastructure.csproj", "{8F3AF982-AF00-4CD2-AB4B-C71B7C8E4BB6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mazad.WebApi", "src\Mazad.WebApi\Mazad.WebApi.csproj", "{79B65DD2-F78F-4F62-960E-2F503C1EF3AF}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {A5031680-7DF8-4EAE-A698-05A593169CAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {A5031680-7DF8-4EAE-A698-05A593169CAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {A5031680-7DF8-4EAE-A698-05A593169CAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {A5031680-7DF8-4EAE-A698-05A593169CAA}.Release|Any CPU.Build.0 = Release|Any CPU
+        {EF789967-F231-466D-93EA-D5BF3E62709C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {EF789967-F231-466D-93EA-D5BF3E62709C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {EF789967-F231-466D-93EA-D5BF3E62709C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {EF789967-F231-466D-93EA-D5BF3E62709C}.Release|Any CPU.Build.0 = Release|Any CPU
+        {8F3AF982-AF00-4CD2-AB4B-C71B7C8E4BB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {8F3AF982-AF00-4CD2-AB4B-C71B7C8E4BB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {8F3AF982-AF00-4CD2-AB4B-C71B7C8E4BB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {8F3AF982-AF00-4CD2-AB4B-C71B7C8E4BB6}.Release|Any CPU.Build.0 = Release|Any CPU
+        {79B65DD2-F78F-4F62-960E-2F503C1EF3AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {79B65DD2-F78F-4F62-960E-2F503C1EF3AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {79B65DD2-F78F-4F62-960E-2F503C1EF3AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {79B65DD2-F78F-4F62-960E-2F503C1EF3AF}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# Mazad.com-Backend
-Mazad.com-Backend
+# Mazad.com Backend
+
+This repository contains the initial backend foundation for Mazad.com built with **.NET 8**, **Entity Framework Core**, **ASP.NET Core Identity**, and **OpenIddict** following an Onion architecture.
+
+## Solution structure
+
+```
+src/
+  Mazad.Domain/            // Domain entities, enums, base types
+  Mazad.Application/       // CQRS handlers, DTOs, validators
+  Mazad.Infrastructure/    // EF Core DbContext, Identity, OpenIddict configuration
+  Mazad.WebApi/            // Minimal API endpoints and composition root
+Mazad.sln                  // Solution file referencing all projects
+```
+
+## Highlights
+
+- Domain model covering categories, listings, bids, watchlists, orders, and CMS resources.
+- Application layer with MediatR-based commands/queries for core workflows (seller CRUD/status transitions, moderation, browsing, bidding, watchlists, category administration).
+- Infrastructure layer wiring EF Core SQL Server provider, ASP.NET Core Identity, and OpenIddict with scope-based policies.
+- Minimal API endpoints for public, seller, and admin surfaces aligned with the MVP specification (listings, categories, bids, watchlists).
+- Swagger/OpenAPI enabled for interactive exploration and testing.
+
+## Getting started
+
+1. Update the connection string in `src/Mazad.WebApi/appsettings.json` to point to your SQL Server instance.
+2. Apply Entity Framework Core migrations (to be added) and run the Web API:
+
+   ```bash
+   dotnet build Mazad.sln
+   dotnet run --project src/Mazad.WebApi/Mazad.WebApi.csproj
+   ```
+
+3. Navigate to `https://localhost:5001/swagger` to explore the endpoints and authenticate using OAuth scopes.
+
+Further enhancements will add migrations, background jobs, full identity flows, testing projects, and additional endpoints listed in the delivery specification.

--- a/src/Mazad.Application/Abstractions/Persistence/IMazadDbContext.cs
+++ b/src/Mazad.Application/Abstractions/Persistence/IMazadDbContext.cs
@@ -1,0 +1,30 @@
+using Mazad.Domain.Entities.Bids;
+using Mazad.Domain.Entities.Catalog;
+using Mazad.Domain.Entities.Cms;
+using Mazad.Domain.Entities.Listings;
+using Mazad.Domain.Entities.Orders;
+using Mazad.Domain.Entities.Taxonomy;
+using Mazad.Domain.Entities.Watchlists;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Abstractions.Persistence;
+
+public interface IMazadDbContext
+{
+    DbSet<Category> Categories { get; }
+    DbSet<AttributeDefinition> AttributeDefinitions { get; }
+    DbSet<VehicleBrand> VehicleBrands { get; }
+    DbSet<VehicleModel> VehicleModels { get; }
+    DbSet<VehicleTrim> VehicleTrims { get; }
+    DbSet<YearRange> YearRanges { get; }
+    DbSet<Listing> Listings { get; }
+    DbSet<ListingMedia> ListingMedia { get; }
+    DbSet<Bid> Bids { get; }
+    DbSet<WatchlistItem> Watchlists { get; }
+    DbSet<Order> Orders { get; }
+    DbSet<Page> Pages { get; }
+    DbSet<Menu> Menus { get; }
+    DbSet<MediaAsset> MediaAssets { get; }
+
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Mazad.Application/Bids/Commands/PlaceBidCommand.cs
+++ b/src/Mazad.Application/Bids/Commands/PlaceBidCommand.cs
@@ -1,0 +1,86 @@
+using System.Linq;
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using Mazad.Domain.Entities.Bids;
+using Mazad.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Bids.Commands;
+
+public record PlaceBidCommand(Guid ListingId, Guid BidderId, decimal Amount) : IRequest<Guid>;
+
+public class PlaceBidCommandHandler : IRequestHandler<PlaceBidCommand, Guid>
+{
+    private readonly IMazadDbContext _context;
+
+    public PlaceBidCommandHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Guid> Handle(PlaceBidCommand request, CancellationToken cancellationToken)
+    {
+        var listing = await _context.Listings
+            .Include(l => l.Bids)
+            .FirstOrDefaultAsync(l => l.Id == request.ListingId, cancellationToken);
+
+        if (listing is null)
+        {
+            throw new NotFoundException("Listing", request.ListingId);
+        }
+
+        if (listing.Type == ListingType.BuyNow && !listing.StartPrice.HasValue)
+        {
+            throw new BusinessRuleException("Bidding is not enabled for this listing.");
+        }
+
+        if (listing.Status != ListingStatus.Active)
+        {
+            throw new BusinessRuleException("Only active listings accept bids.");
+        }
+
+        if (listing.EndAt.HasValue && listing.EndAt <= DateTimeOffset.UtcNow)
+        {
+            throw new BusinessRuleException("The auction has already ended.");
+        }
+
+        var highestBid = listing.Bids
+            .Where(b => b.Status == BidStatus.Placed || b.Status == BidStatus.Winning)
+            .OrderByDescending(b => b.Amount)
+            .FirstOrDefault();
+
+        var minimumBid = highestBid != null
+            ? highestBid.Amount + (listing.BidIncrement ?? 1)
+            : listing.StartPrice ?? 1;
+
+        if (request.Amount < minimumBid)
+        {
+            throw new BusinessRuleException($"Bid amount must be at least {minimumBid:0.##}.");
+        }
+
+        if (highestBid != null)
+        {
+            highestBid.Status = BidStatus.Outbid;
+            highestBid.UpdatedAt = DateTimeOffset.UtcNow;
+            highestBid.UpdatedById = request.BidderId;
+        }
+
+        var bid = new Bid
+        {
+            Id = Guid.NewGuid(),
+            ListingId = listing.Id,
+            BidderId = request.BidderId,
+            Amount = request.Amount,
+            PlacedAt = DateTimeOffset.UtcNow,
+            Status = BidStatus.Winning,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedById = request.BidderId
+        };
+
+        listing.Bids.Add(bid);
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return bid.Id;
+    }
+}

--- a/src/Mazad.Application/Categories/Commands/CreateCategoryCommand.cs
+++ b/src/Mazad.Application/Categories/Commands/CreateCategoryCommand.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using Mazad.Domain.Entities.Catalog;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Categories.Commands;
+
+public record CreateCategoryCommand(Guid? ParentId, string Name, string? Slug, string? AttributesSchema) : IRequest<CategoryDto>;
+
+public class CreateCategoryCommandHandler : IRequestHandler<CreateCategoryCommand, CategoryDto>
+{
+    private readonly IMazadDbContext _context;
+
+    public CreateCategoryCommandHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<CategoryDto> Handle(CreateCategoryCommand request, CancellationToken cancellationToken)
+    {
+        if (request.ParentId.HasValue)
+        {
+            var parentExists = await _context.Categories.AnyAsync(c => c.Id == request.ParentId, cancellationToken);
+            if (!parentExists)
+            {
+                throw new NotFoundException("Category", request.ParentId.Value);
+            }
+        }
+
+        var slug = string.IsNullOrWhiteSpace(request.Slug)
+            ? GenerateSlug(request.Name)
+            : request.Slug!.ToLowerInvariant();
+
+        var slugExists = await _context.Categories.AnyAsync(c => c.Slug == slug, cancellationToken);
+        if (slugExists)
+        {
+            throw new BusinessRuleException($"A category with slug '{slug}' already exists.");
+        }
+
+        var category = new Category
+        {
+            Id = Guid.NewGuid(),
+            ParentId = request.ParentId,
+            Name = request.Name,
+            Slug = slug,
+            AttributesSchema = request.AttributesSchema
+        };
+
+        await _context.Categories.AddAsync(category, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return category.ToDto();
+    }
+
+    private static string GenerateSlug(string value)
+    {
+        var slug = new string(value.ToLowerInvariant()
+            .Where(c => char.IsLetterOrDigit(c) || char.IsWhiteSpace(c) || c == '-').ToArray());
+        slug = slug.Replace(' ', '-');
+        slug = System.Text.RegularExpressions.Regex.Replace(slug, "-+", "-");
+        return slug.Trim('-');
+    }
+}

--- a/src/Mazad.Application/Categories/Commands/DeleteCategoryCommand.cs
+++ b/src/Mazad.Application/Categories/Commands/DeleteCategoryCommand.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Categories.Commands;
+
+public record DeleteCategoryCommand(Guid Id) : IRequest<Unit>;
+
+public class DeleteCategoryCommandHandler : IRequestHandler<DeleteCategoryCommand, Unit>
+{
+    private readonly IMazadDbContext _context;
+
+    public DeleteCategoryCommandHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Unit> Handle(DeleteCategoryCommand request, CancellationToken cancellationToken)
+    {
+        var category = await _context.Categories
+            .Include(c => c.Children)
+            .Include(c => c.Listings)
+            .FirstOrDefaultAsync(c => c.Id == request.Id, cancellationToken);
+
+        if (category is null)
+        {
+            throw new NotFoundException("Category", request.Id);
+        }
+
+        if (category.Children.Any())
+        {
+            throw new BusinessRuleException("Cannot delete a category that has child categories.");
+        }
+
+        if (category.Listings.Any())
+        {
+            throw new BusinessRuleException("Cannot delete a category that has listings assigned.");
+        }
+
+        _context.Categories.Remove(category);
+        await _context.SaveChangesAsync(cancellationToken);
+        return Unit.Value;
+    }
+}

--- a/src/Mazad.Application/Categories/Commands/UpdateCategoryCommand.cs
+++ b/src/Mazad.Application/Categories/Commands/UpdateCategoryCommand.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Categories.Commands;
+
+public record UpdateCategoryCommand(Guid Id, string Name, string? Slug, string? AttributesSchema) : IRequest<CategoryDto>;
+
+public class UpdateCategoryCommandHandler : IRequestHandler<UpdateCategoryCommand, CategoryDto>
+{
+    private readonly IMazadDbContext _context;
+
+    public UpdateCategoryCommandHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<CategoryDto> Handle(UpdateCategoryCommand request, CancellationToken cancellationToken)
+    {
+        var category = await _context.Categories
+            .FirstOrDefaultAsync(c => c.Id == request.Id, cancellationToken);
+
+        if (category is null)
+        {
+            throw new NotFoundException("Category", request.Id);
+        }
+
+        var slug = string.IsNullOrWhiteSpace(request.Slug)
+            ? GenerateSlug(request.Name)
+            : request.Slug!.ToLowerInvariant();
+
+        var slugConflict = await _context.Categories
+            .AnyAsync(c => c.Id != request.Id && c.Slug == slug, cancellationToken);
+
+        if (slugConflict)
+        {
+            throw new BusinessRuleException($"A category with slug '{slug}' already exists.");
+        }
+
+        category.Name = request.Name;
+        category.Slug = slug;
+        category.AttributesSchema = request.AttributesSchema;
+        category.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return category.ToDto();
+    }
+
+    private static string GenerateSlug(string value)
+    {
+        var slug = new string(value.ToLowerInvariant()
+            .Where(c => char.IsLetterOrDigit(c) || char.IsWhiteSpace(c) || c == '-').ToArray());
+        slug = slug.Replace(' ', '-');
+        slug = System.Text.RegularExpressions.Regex.Replace(slug, "-+", "-");
+        return slug.Trim('-');
+    }
+}

--- a/src/Mazad.Application/Categories/Queries/GetCategoriesTreeQuery.cs
+++ b/src/Mazad.Application/Categories/Queries/GetCategoriesTreeQuery.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Categories.Queries;
+
+public record GetCategoriesTreeQuery : IRequest<IReadOnlyCollection<CategoryDto>>;
+
+public class GetCategoriesTreeQueryHandler : IRequestHandler<GetCategoriesTreeQuery, IReadOnlyCollection<CategoryDto>>
+{
+    private readonly IMazadDbContext _context;
+
+    public GetCategoriesTreeQueryHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IReadOnlyCollection<CategoryDto>> Handle(GetCategoriesTreeQuery request, CancellationToken cancellationToken)
+    {
+        var categories = await _context.Categories
+            .AsNoTracking()
+            .Include(c => c.Children)
+            .ToListAsync(cancellationToken);
+        foreach (var category in categories)
+        {
+            category.Children = categories.Where(c => c.ParentId == category.Id).ToList();
+        }
+
+        var roots = categories.Where(c => c.ParentId == null).ToList();
+        return roots.Select(c => c.ToDto()).ToArray();
+    }
+}

--- a/src/Mazad.Application/Categories/Queries/GetCategoryByIdQuery.cs
+++ b/src/Mazad.Application/Categories/Queries/GetCategoryByIdQuery.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Categories.Queries;
+
+public record GetCategoryByIdQuery(Guid Id) : IRequest<CategoryDto>;
+
+public class GetCategoryByIdQueryHandler : IRequestHandler<GetCategoryByIdQuery, CategoryDto>
+{
+    private readonly IMazadDbContext _context;
+
+    public GetCategoryByIdQueryHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<CategoryDto> Handle(GetCategoryByIdQuery request, CancellationToken cancellationToken)
+    {
+        var category = await _context.Categories
+            .AsNoTracking()
+            .Include(c => c.Children)
+            .FirstOrDefaultAsync(c => c.Id == request.Id, cancellationToken);
+
+        if (category is null)
+        {
+            throw new NotFoundException("Category", request.Id);
+        }
+
+        category.Children = await _context.Categories
+            .Where(c => c.ParentId == category.Id)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        return category.ToDto();
+    }
+}

--- a/src/Mazad.Application/Common/AssemblyReference.cs
+++ b/src/Mazad.Application/Common/AssemblyReference.cs
@@ -1,0 +1,8 @@
+using System.Reflection;
+
+namespace Mazad.Application.Common;
+
+public static class AssemblyReference
+{
+    public static readonly Assembly Assembly = typeof(AssemblyReference).Assembly;
+}

--- a/src/Mazad.Application/Common/Exceptions/BusinessRuleException.cs
+++ b/src/Mazad.Application/Common/Exceptions/BusinessRuleException.cs
@@ -1,0 +1,9 @@
+namespace Mazad.Application.Common.Exceptions;
+
+public class BusinessRuleException : Exception
+{
+    public BusinessRuleException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Mazad.Application/Common/Exceptions/NotFoundException.cs
+++ b/src/Mazad.Application/Common/Exceptions/NotFoundException.cs
@@ -1,0 +1,15 @@
+namespace Mazad.Application.Common.Exceptions;
+
+public class NotFoundException : Exception
+{
+    public NotFoundException(string resource, object key)
+        : base($"{resource} with key '{key}' was not found.")
+    {
+        Resource = resource;
+        Key = key;
+    }
+
+    public string Resource { get; }
+
+    public object Key { get; }
+}

--- a/src/Mazad.Application/Common/Mappings/CategoryMappings.cs
+++ b/src/Mazad.Application/Common/Mappings/CategoryMappings.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+using Mazad.Application.Common.Models;
+using Mazad.Domain.Entities.Catalog;
+
+namespace Mazad.Application.Common.Mappings;
+
+public static class CategoryMappings
+{
+    public static CategoryDto ToDto(this Category category)
+    {
+        return new CategoryDto
+        {
+            Id = category.Id,
+            Name = category.Name,
+            Slug = category.Slug,
+            ParentId = category.ParentId,
+            AttributesSchema = category.AttributesSchema,
+            Children = category.Children.Select(ToDto).ToArray()
+        };
+    }
+}

--- a/src/Mazad.Application/Common/Mappings/ListingMappings.cs
+++ b/src/Mazad.Application/Common/Mappings/ListingMappings.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using Mazad.Application.Common.Models;
+using Mazad.Domain.Entities.Listings;
+
+namespace Mazad.Application.Common.Mappings;
+
+public static class ListingMappings
+{
+    public static ListingDto ToDto(this Listing listing)
+    {
+        return new ListingDto
+        {
+            Id = listing.Id,
+            SellerId = listing.SellerId,
+            CategoryId = listing.CategoryId,
+            Title = listing.Title,
+            Slug = listing.Slug,
+            Description = listing.Description,
+            Location = listing.Location,
+            Attributes = listing.Attributes,
+            Type = listing.Type,
+            Status = listing.Status,
+            StartAt = listing.StartAt,
+            EndAt = listing.EndAt,
+            StartPrice = listing.StartPrice,
+            ReservePrice = listing.ReservePrice,
+            BidIncrement = listing.BidIncrement,
+            BuyNowPrice = listing.BuyNowPrice,
+            Views = listing.Views,
+            WatchCount = listing.WatchCount,
+            Media = listing.Media
+                .OrderBy(m => m.SortOrder)
+                .Select(m => new ListingMediaDto
+                {
+                    Id = m.Id,
+                    Url = m.Url,
+                    Type = m.Type,
+                    SortOrder = m.SortOrder,
+                    IsCover = m.IsCover
+                })
+                .ToArray()
+        };
+    }
+}

--- a/src/Mazad.Application/Common/Models/CategoryDto.cs
+++ b/src/Mazad.Application/Common/Models/CategoryDto.cs
@@ -1,0 +1,11 @@
+namespace Mazad.Application.Common.Models;
+
+public record CategoryDto
+{
+    public Guid Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string Slug { get; init; } = string.Empty;
+    public Guid? ParentId { get; init; }
+    public string? AttributesSchema { get; init; }
+    public IReadOnlyCollection<CategoryDto> Children { get; init; } = Array.Empty<CategoryDto>();
+}

--- a/src/Mazad.Application/Common/Models/ListingDto.cs
+++ b/src/Mazad.Application/Common/Models/ListingDto.cs
@@ -1,0 +1,35 @@
+using Mazad.Domain.Enums;
+
+namespace Mazad.Application.Common.Models;
+
+public record ListingDto
+{
+    public Guid Id { get; init; }
+    public Guid SellerId { get; init; }
+    public Guid CategoryId { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Slug { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public string? Location { get; init; }
+    public string? Attributes { get; init; }
+    public ListingType Type { get; init; }
+    public ListingStatus Status { get; init; }
+    public DateTimeOffset? StartAt { get; init; }
+    public DateTimeOffset? EndAt { get; init; }
+    public decimal? StartPrice { get; init; }
+    public decimal? ReservePrice { get; init; }
+    public decimal? BidIncrement { get; init; }
+    public decimal? BuyNowPrice { get; init; }
+    public int Views { get; init; }
+    public int WatchCount { get; init; }
+    public IReadOnlyCollection<ListingMediaDto> Media { get; init; } = Array.Empty<ListingMediaDto>();
+}
+
+public record ListingMediaDto
+{
+    public Guid Id { get; init; }
+    public string Url { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public int SortOrder { get; init; }
+    public bool IsCover { get; init; }
+}

--- a/src/Mazad.Application/Common/Models/PagedResult.cs
+++ b/src/Mazad.Application/Common/Models/PagedResult.cs
@@ -1,0 +1,3 @@
+namespace Mazad.Application.Common.Models;
+
+public record PagedResult<T>(IReadOnlyCollection<T> Items, int Page, int PageSize, int TotalCount);

--- a/src/Mazad.Application/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mazad.Application/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using Mazad.Application.Common;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mazad.Application.DependencyInjection;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(AssemblyReference.Assembly));
+        services.AddValidatorsFromAssembly(AssemblyReference.Assembly);
+        return services;
+    }
+}

--- a/src/Mazad.Application/Listings/Commands/Create/CreateListingCommand.cs
+++ b/src/Mazad.Application/Listings/Commands/Create/CreateListingCommand.cs
@@ -1,0 +1,113 @@
+using System.Linq;
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using Mazad.Domain.Entities.Listings;
+using Mazad.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Listings.Commands.Create;
+
+public record CreateListingCommand : IRequest<ListingDto>
+{
+    public Guid SellerId { get; init; }
+    public Guid CategoryId { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public string? Location { get; init; }
+    public string? Attributes { get; init; }
+    public ListingType Type { get; init; } = ListingType.Auction;
+    public DateTimeOffset? StartAt { get; init; }
+    public DateTimeOffset? EndAt { get; init; }
+    public decimal? StartPrice { get; init; }
+    public decimal? ReservePrice { get; init; }
+    public decimal? BidIncrement { get; init; }
+    public decimal? BuyNowPrice { get; init; }
+    public IReadOnlyCollection<CreateListingMediaRequest> Media { get; init; } = Array.Empty<CreateListingMediaRequest>();
+}
+
+public record CreateListingMediaRequest
+{
+    public string Url { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public bool IsCover { get; init; }
+    public int? SortOrder { get; init; }
+}
+
+public class CreateListingCommandHandler : IRequestHandler<CreateListingCommand, ListingDto>
+{
+    private readonly IMazadDbContext _context;
+
+    public CreateListingCommandHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<ListingDto> Handle(CreateListingCommand request, CancellationToken cancellationToken)
+    {
+        var categoryExists = await _context.Categories
+            .AnyAsync(c => c.Id == request.CategoryId, cancellationToken);
+
+        if (!categoryExists)
+        {
+            throw new NotFoundException("Category", request.CategoryId);
+        }
+
+        var now = DateTimeOffset.UtcNow;
+
+        var listing = new Listing
+        {
+            Id = Guid.NewGuid(),
+            SellerId = request.SellerId,
+            CategoryId = request.CategoryId,
+            Title = request.Title,
+            Slug = GenerateSlug(request.Title),
+            Description = request.Description,
+            Location = request.Location,
+            Attributes = request.Attributes,
+            Type = request.Type,
+            StartAt = request.StartAt,
+            EndAt = request.EndAt,
+            StartPrice = request.StartPrice,
+            ReservePrice = request.ReservePrice,
+            BidIncrement = request.BidIncrement,
+            BuyNowPrice = request.BuyNowPrice,
+            CreatedAt = now,
+            CreatedById = request.SellerId,
+            Status = ListingStatus.Draft
+        };
+
+        var media = request.Media.Select((m, index) => new ListingMedia
+        {
+            Id = Guid.NewGuid(),
+            ListingId = listing.Id,
+            Url = m.Url,
+            Type = m.Type,
+            IsCover = m.IsCover,
+            SortOrder = m.SortOrder ?? index,
+            CreatedAt = now,
+            CreatedById = request.SellerId
+        }).ToList();
+
+        if (media.Count > 0)
+        {
+            listing.Media = media;
+        }
+
+        await _context.Listings.AddAsync(listing, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return listing.ToDto();
+    }
+
+    private static string GenerateSlug(string value)
+    {
+        var slug = new string(value.ToLowerInvariant()
+            .Where(c => char.IsLetterOrDigit(c) || char.IsWhiteSpace(c) || c == '-').ToArray());
+        slug = slug.Replace(' ', '-');
+        slug = System.Text.RegularExpressions.Regex.Replace(slug, "-+", "-");
+        return slug.Trim('-');
+    }
+}

--- a/src/Mazad.Application/Listings/Commands/Create/CreateListingCommandValidator.cs
+++ b/src/Mazad.Application/Listings/Commands/Create/CreateListingCommandValidator.cs
@@ -1,0 +1,33 @@
+using FluentValidation;
+using Mazad.Domain.Enums;
+
+namespace Mazad.Application.Listings.Commands.Create;
+
+public class CreateListingCommandValidator : AbstractValidator<CreateListingCommand>
+{
+    public CreateListingCommandValidator()
+    {
+        RuleFor(x => x.SellerId).NotEmpty();
+        RuleFor(x => x.CategoryId).NotEmpty();
+        RuleFor(x => x.Title).NotEmpty().MaximumLength(200);
+        RuleFor(x => x.Description).NotEmpty();
+        RuleFor(x => x.Type).IsInEnum();
+
+        RuleFor(x => x.StartPrice).GreaterThanOrEqualTo(0).When(x => x.StartPrice.HasValue);
+        RuleFor(x => x.ReservePrice).GreaterThanOrEqualTo(0).When(x => x.ReservePrice.HasValue);
+        RuleFor(x => x.BidIncrement).GreaterThan(0).When(x => x.BidIncrement.HasValue);
+        RuleFor(x => x.BuyNowPrice).GreaterThan(0).When(x => x.Type != ListingType.Auction);
+
+        When(x => x.StartAt.HasValue && x.EndAt.HasValue, () =>
+        {
+            RuleFor(x => x.EndAt).GreaterThan(x => x.StartAt);
+        });
+
+        RuleForEach(x => x.Media).ChildRules(media =>
+        {
+            media.RuleFor(m => m.Url).NotEmpty().MaximumLength(2048);
+            media.RuleFor(m => m.Type).NotEmpty();
+            media.RuleFor(m => m.SortOrder).GreaterThanOrEqualTo(0).When(m => m.SortOrder.HasValue);
+        });
+    }
+}

--- a/src/Mazad.Application/Listings/Commands/Moderation/ApproveListingCommand.cs
+++ b/src/Mazad.Application/Listings/Commands/Moderation/ApproveListingCommand.cs
@@ -1,0 +1,50 @@
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using Mazad.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Listings.Commands.Moderation;
+
+public record ApproveListingCommand(Guid ListingId, Guid AdminId, string? Notes = null) : IRequest<ListingDto>;
+
+public class ApproveListingCommandHandler : IRequestHandler<ApproveListingCommand, ListingDto>
+{
+    private readonly IMazadDbContext _context;
+
+    public ApproveListingCommandHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<ListingDto> Handle(ApproveListingCommand request, CancellationToken cancellationToken)
+    {
+        var listing = await _context.Listings
+            .Include(l => l.Media)
+            .FirstOrDefaultAsync(l => l.Id == request.ListingId, cancellationToken);
+
+        if (listing is null)
+        {
+            throw new NotFoundException("Listing", request.ListingId);
+        }
+
+        if (listing.Status != ListingStatus.PendingReview)
+        {
+            throw new BusinessRuleException("Only listings pending review can be approved.");
+        }
+
+        listing.Status = listing.StartAt.HasValue && listing.StartAt > DateTimeOffset.UtcNow
+            ? ListingStatus.Approved
+            : ListingStatus.Active;
+        listing.ModerationNotes = request.Notes;
+        listing.RejectionReason = null;
+        listing.UpdatedAt = DateTimeOffset.UtcNow;
+        listing.UpdatedById = request.AdminId;
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return listing.ToDto();
+    }
+}

--- a/src/Mazad.Application/Listings/Commands/Moderation/RejectListingCommand.cs
+++ b/src/Mazad.Application/Listings/Commands/Moderation/RejectListingCommand.cs
@@ -1,0 +1,47 @@
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using Mazad.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Listings.Commands.Moderation;
+
+public record RejectListingCommand(Guid ListingId, Guid AdminId, string Reason) : IRequest<ListingDto>;
+
+public class RejectListingCommandHandler : IRequestHandler<RejectListingCommand, ListingDto>
+{
+    private readonly IMazadDbContext _context;
+
+    public RejectListingCommandHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<ListingDto> Handle(RejectListingCommand request, CancellationToken cancellationToken)
+    {
+        var listing = await _context.Listings
+            .Include(l => l.Media)
+            .FirstOrDefaultAsync(l => l.Id == request.ListingId, cancellationToken);
+
+        if (listing is null)
+        {
+            throw new NotFoundException("Listing", request.ListingId);
+        }
+
+        if (listing.Status != ListingStatus.PendingReview)
+        {
+            throw new BusinessRuleException("Only listings pending review can be rejected.");
+        }
+
+        listing.Status = ListingStatus.Rejected;
+        listing.RejectionReason = request.Reason;
+        listing.UpdatedAt = DateTimeOffset.UtcNow;
+        listing.UpdatedById = request.AdminId;
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return listing.ToDto();
+    }
+}

--- a/src/Mazad.Application/Listings/Commands/Submit/SubmitListingCommand.cs
+++ b/src/Mazad.Application/Listings/Commands/Submit/SubmitListingCommand.cs
@@ -1,0 +1,52 @@
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using Mazad.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Listings.Commands.Submit;
+
+public record SubmitListingCommand(Guid ListingId, Guid SellerId) : IRequest<ListingDto>;
+
+public class SubmitListingCommandHandler : IRequestHandler<SubmitListingCommand, ListingDto>
+{
+    private readonly IMazadDbContext _context;
+
+    public SubmitListingCommandHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<ListingDto> Handle(SubmitListingCommand request, CancellationToken cancellationToken)
+    {
+        var listing = await _context.Listings
+            .Include(l => l.Media)
+            .FirstOrDefaultAsync(l => l.Id == request.ListingId, cancellationToken);
+
+        if (listing is null)
+        {
+            throw new NotFoundException("Listing", request.ListingId);
+        }
+
+        if (listing.SellerId != request.SellerId)
+        {
+            throw new BusinessRuleException("You do not have permission to submit this listing.");
+        }
+
+        if (listing.Status != ListingStatus.Draft && listing.Status != ListingStatus.Rejected)
+        {
+            throw new BusinessRuleException("Only draft or rejected listings can be submitted for review.");
+        }
+
+        listing.Status = ListingStatus.PendingReview;
+        listing.UpdatedAt = DateTimeOffset.UtcNow;
+        listing.UpdatedById = request.SellerId;
+        listing.RejectionReason = null;
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return listing.ToDto();
+    }
+}

--- a/src/Mazad.Application/Listings/Commands/UpdateStatus/UpdateListingStatusCommand.cs
+++ b/src/Mazad.Application/Listings/Commands/UpdateStatus/UpdateListingStatusCommand.cs
@@ -1,0 +1,83 @@
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using Mazad.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Listings.Commands.UpdateStatus;
+
+public record UpdateListingStatusCommand(Guid ListingId, Guid SellerId, ListingStatus TargetStatus, string? Reason = null) : IRequest<ListingDto>;
+
+public class UpdateListingStatusCommandHandler : IRequestHandler<UpdateListingStatusCommand, ListingDto>
+{
+    private readonly IMazadDbContext _context;
+
+    public UpdateListingStatusCommandHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<ListingDto> Handle(UpdateListingStatusCommand request, CancellationToken cancellationToken)
+    {
+        var listing = await _context.Listings
+            .Include(l => l.Media)
+            .FirstOrDefaultAsync(l => l.Id == request.ListingId, cancellationToken);
+
+        if (listing is null)
+        {
+            throw new NotFoundException("Listing", request.ListingId);
+        }
+
+        if (listing.SellerId != request.SellerId)
+        {
+            throw new BusinessRuleException("You do not have permission to change this listing status.");
+        }
+
+        EnsureTransitionAllowed(listing.Status, request.TargetStatus);
+
+        listing.Status = request.TargetStatus;
+        listing.UpdatedAt = DateTimeOffset.UtcNow;
+        listing.UpdatedById = request.SellerId;
+
+        if (request.TargetStatus == ListingStatus.Cancelled)
+        {
+            listing.ModerationNotes = request.Reason;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return listing.ToDto();
+    }
+
+    private static void EnsureTransitionAllowed(ListingStatus current, ListingStatus target)
+    {
+        if (current == target)
+        {
+            return;
+        }
+
+        switch (target)
+        {
+            case ListingStatus.Paused when current != ListingStatus.Active:
+                throw new BusinessRuleException("Only active listings can be paused.");
+            case ListingStatus.Active when current != ListingStatus.Paused && current != ListingStatus.Approved:
+                throw new BusinessRuleException("Only paused or approved listings can be activated by the seller.");
+            case ListingStatus.Cancelled when current is ListingStatus.Draft or ListingStatus.PendingReview or ListingStatus.Active:
+                break;
+            default:
+                if (target is ListingStatus.Sold or ListingStatus.Expired)
+                {
+                    throw new BusinessRuleException("The requested status change is managed by the platform.");
+                }
+
+                if (target is ListingStatus.PendingReview or ListingStatus.Approved or ListingStatus.Rejected)
+                {
+                    throw new BusinessRuleException("The requested status is managed by moderation.");
+                }
+
+                break;
+        }
+    }
+}

--- a/src/Mazad.Application/Listings/Queries/GetAdminListings/GetAdminListingsQuery.cs
+++ b/src/Mazad.Application/Listings/Queries/GetAdminListings/GetAdminListingsQuery.cs
@@ -1,0 +1,73 @@
+using System.Linq;
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using Mazad.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Listings.Queries.GetAdminListings;
+
+public record GetAdminListingsQuery(
+    string? Search,
+    Guid? SellerId,
+    Guid? CategoryId,
+    ListingStatus? Status,
+    string? Sort,
+    int Page = 1,
+    int PageSize = 20) : IRequest<PagedResult<ListingDto>>;
+
+public class GetAdminListingsQueryHandler : IRequestHandler<GetAdminListingsQuery, PagedResult<ListingDto>>
+{
+    private readonly IMazadDbContext _context;
+
+    public GetAdminListingsQueryHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<PagedResult<ListingDto>> Handle(GetAdminListingsQuery request, CancellationToken cancellationToken)
+    {
+        var query = _context.Listings
+            .AsNoTracking()
+            .Include(l => l.Media)
+            .AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(request.Search))
+        {
+            var term = request.Search.Trim();
+            query = query.Where(l => EF.Functions.Like(l.Title, $"%{term}%") || EF.Functions.Like(l.Description, $"%{term}%"));
+        }
+
+        if (request.SellerId.HasValue)
+        {
+            query = query.Where(l => l.SellerId == request.SellerId);
+        }
+
+        if (request.CategoryId.HasValue)
+        {
+            query = query.Where(l => l.CategoryId == request.CategoryId);
+        }
+
+        if (request.Status.HasValue)
+        {
+            query = query.Where(l => l.Status == request.Status);
+        }
+
+        query = request.Sort switch
+        {
+            "created" => query.OrderBy(l => l.CreatedAt),
+            "-created" => query.OrderByDescending(l => l.CreatedAt),
+            _ => query.OrderByDescending(l => l.UpdatedAt ?? l.CreatedAt)
+        };
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query
+            .Skip((request.Page - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .ToListAsync(cancellationToken);
+
+        var dtos = items.Select(l => l.ToDto()).ToList();
+        return new PagedResult<ListingDto>(dtos, request.Page, request.PageSize, total);
+    }
+}

--- a/src/Mazad.Application/Listings/Queries/GetById/GetListingByIdQuery.cs
+++ b/src/Mazad.Application/Listings/Queries/GetById/GetListingByIdQuery.cs
@@ -1,0 +1,35 @@
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Listings.Queries.GetById;
+
+public record GetListingByIdQuery(Guid Id) : IRequest<ListingDto>;
+
+public class GetListingByIdQueryHandler : IRequestHandler<GetListingByIdQuery, ListingDto>
+{
+    private readonly IMazadDbContext _context;
+
+    public GetListingByIdQueryHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<ListingDto> Handle(GetListingByIdQuery request, CancellationToken cancellationToken)
+    {
+        var listing = await _context.Listings
+            .AsNoTracking()
+            .Include(l => l.Media)
+            .FirstOrDefaultAsync(l => l.Id == request.Id, cancellationToken);
+
+        if (listing is null)
+        {
+            throw new NotFoundException("Listing", request.Id);
+        }
+
+        return listing.ToDto();
+    }
+}

--- a/src/Mazad.Application/Listings/Queries/GetPublicListings/GetPublicListingsQuery.cs
+++ b/src/Mazad.Application/Listings/Queries/GetPublicListings/GetPublicListingsQuery.cs
@@ -1,0 +1,74 @@
+using System.Linq;
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using Mazad.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Listings.Queries.GetPublicListings;
+
+public record GetPublicListingsQuery(
+    string? Search,
+    Guid? CategoryId,
+    ListingType? Type,
+    string? Sort,
+    int Page = 1,
+    int PageSize = 20) : IRequest<PagedResult<ListingDto>>;
+
+public class GetPublicListingsQueryHandler : IRequestHandler<GetPublicListingsQuery, PagedResult<ListingDto>>
+{
+    private readonly IMazadDbContext _context;
+
+    public GetPublicListingsQueryHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<PagedResult<ListingDto>> Handle(GetPublicListingsQuery request, CancellationToken cancellationToken)
+    {
+        var query = _context.Listings
+            .AsNoTracking()
+            .Include(l => l.Media)
+            .Where(l => l.Status == ListingStatus.Active || l.Status == ListingStatus.Approved);
+
+        if (!string.IsNullOrWhiteSpace(request.Search))
+        {
+            var term = request.Search.Trim();
+            query = query.Where(l => EF.Functions.Like(l.Title, $"%{term}%") || EF.Functions.Like(l.Description, $"%{term}%"));
+        }
+
+        if (request.CategoryId.HasValue)
+        {
+            query = query.Where(l => l.CategoryId == request.CategoryId);
+        }
+
+        if (request.Type.HasValue)
+        {
+            query = query.Where(l => l.Type == request.Type);
+        }
+
+        query = ApplySort(query, request.Sort);
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query
+            .Skip((request.Page - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .ToListAsync(cancellationToken);
+
+        var dtos = items.Select(l => l.ToDto()).ToList();
+        return new PagedResult<ListingDto>(dtos, request.Page, request.PageSize, total);
+    }
+
+    private static IQueryable<Domain.Entities.Listings.Listing> ApplySort(IQueryable<Domain.Entities.Listings.Listing> query, string? sort)
+    {
+        return sort switch
+        {
+            "price" => query.OrderBy(l => l.BuyNowPrice ?? l.StartPrice),
+            "-price" => query.OrderByDescending(l => l.BuyNowPrice ?? l.StartPrice),
+            "endAt" => query.OrderBy(l => l.EndAt),
+            "-endAt" => query.OrderByDescending(l => l.EndAt),
+            _ => query.OrderByDescending(l => l.CreatedAt)
+        };
+    }
+}

--- a/src/Mazad.Application/Listings/Queries/GetSellerListings/GetSellerListingsQuery.cs
+++ b/src/Mazad.Application/Listings/Queries/GetSellerListings/GetSellerListingsQuery.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Listings.Queries.GetSellerListings;
+
+public record GetSellerListingsQuery(Guid SellerId, int Page = 1, int PageSize = 20) : IRequest<PagedResult<ListingDto>>;
+
+public class GetSellerListingsQueryHandler : IRequestHandler<GetSellerListingsQuery, PagedResult<ListingDto>>
+{
+    private readonly IMazadDbContext _context;
+
+    public GetSellerListingsQueryHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<PagedResult<ListingDto>> Handle(GetSellerListingsQuery request, CancellationToken cancellationToken)
+    {
+        var query = _context.Listings
+            .AsNoTracking()
+            .Include(l => l.Media)
+            .Where(l => l.SellerId == request.SellerId)
+            .OrderByDescending(l => l.CreatedAt);
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query
+            .Skip((request.Page - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .ToListAsync(cancellationToken);
+
+        var dtos = items.Select(l => l.ToDto()).ToList();
+
+        return new PagedResult<ListingDto>(dtos, request.Page, request.PageSize, total);
+    }
+}

--- a/src/Mazad.Application/Mazad.Application.csproj
+++ b/src/Mazad.Application/Mazad.Application.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.2.0" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mazad.Domain\Mazad.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Mazad.Application/Watchlists/Commands/AddToWatchlistCommand.cs
+++ b/src/Mazad.Application/Watchlists/Commands/AddToWatchlistCommand.cs
@@ -1,0 +1,52 @@
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using Mazad.Domain.Entities.Watchlists;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Watchlists.Commands;
+
+public record AddToWatchlistCommand(Guid UserId, Guid ListingId) : IRequest<Unit>;
+
+public class AddToWatchlistCommandHandler : IRequestHandler<AddToWatchlistCommand, Unit>
+{
+    private readonly IMazadDbContext _context;
+
+    public AddToWatchlistCommandHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Unit> Handle(AddToWatchlistCommand request, CancellationToken cancellationToken)
+    {
+        var listingExists = await _context.Listings
+            .AnyAsync(l => l.Id == request.ListingId, cancellationToken);
+
+        if (!listingExists)
+        {
+            throw new NotFoundException("Listing", request.ListingId);
+        }
+
+        var alreadyExists = await _context.Watchlists
+            .AnyAsync(w => w.UserId == request.UserId && w.ListingId == request.ListingId, cancellationToken);
+
+        if (alreadyExists)
+        {
+            return Unit.Value;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+
+        _context.Watchlists.Add(new WatchlistItem
+        {
+            Id = Guid.NewGuid(),
+            UserId = request.UserId,
+            ListingId = request.ListingId,
+            CreatedAt = now,
+            CreatedById = request.UserId
+        });
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return Unit.Value;
+    }
+}

--- a/src/Mazad.Application/Watchlists/Commands/RemoveFromWatchlistCommand.cs
+++ b/src/Mazad.Application/Watchlists/Commands/RemoveFromWatchlistCommand.cs
@@ -1,0 +1,33 @@
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Exceptions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Watchlists.Commands;
+
+public record RemoveFromWatchlistCommand(Guid UserId, Guid ListingId) : IRequest<Unit>;
+
+public class RemoveFromWatchlistCommandHandler : IRequestHandler<RemoveFromWatchlistCommand, Unit>
+{
+    private readonly IMazadDbContext _context;
+
+    public RemoveFromWatchlistCommandHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Unit> Handle(RemoveFromWatchlistCommand request, CancellationToken cancellationToken)
+    {
+        var item = await _context.Watchlists
+            .FirstOrDefaultAsync(w => w.UserId == request.UserId && w.ListingId == request.ListingId, cancellationToken);
+
+        if (item is null)
+        {
+            throw new NotFoundException("WatchlistItem", request.ListingId);
+        }
+
+        _context.Watchlists.Remove(item);
+        await _context.SaveChangesAsync(cancellationToken);
+        return Unit.Value;
+    }
+}

--- a/src/Mazad.Application/Watchlists/Queries/GetMyWatchlistQuery.cs
+++ b/src/Mazad.Application/Watchlists/Queries/GetMyWatchlistQuery.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Application.Common.Mappings;
+using Mazad.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Application.Watchlists.Queries;
+
+public record GetMyWatchlistQuery(Guid UserId, int Page = 1, int PageSize = 20) : IRequest<PagedResult<ListingDto>>;
+
+public class GetMyWatchlistQueryHandler : IRequestHandler<GetMyWatchlistQuery, PagedResult<ListingDto>>
+{
+    private readonly IMazadDbContext _context;
+
+    public GetMyWatchlistQueryHandler(IMazadDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<PagedResult<ListingDto>> Handle(GetMyWatchlistQuery request, CancellationToken cancellationToken)
+    {
+        var query = _context.Watchlists
+            .AsNoTracking()
+            .Where(w => w.UserId == request.UserId)
+            .Join(
+                _context.Listings.Include(l => l.Media),
+                w => w.ListingId,
+                l => l.Id,
+                (w, l) => l)
+            .OrderByDescending(l => l.CreatedAt);
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query
+            .Skip((request.Page - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .ToListAsync(cancellationToken);
+
+        var dtos = items.Select(l => l.ToDto()).ToList();
+        return new PagedResult<ListingDto>(dtos, request.Page, request.PageSize, total);
+    }
+}

--- a/src/Mazad.Domain/Common/AuditableEntity.cs
+++ b/src/Mazad.Domain/Common/AuditableEntity.cs
@@ -1,0 +1,12 @@
+namespace Mazad.Domain.Common;
+
+public abstract class AuditableEntity : BaseEntity
+{
+    public DateTimeOffset CreatedAt { get; set; }
+    public Guid? CreatedById { get; set; }
+    public DateTimeOffset? UpdatedAt { get; set; }
+    public Guid? UpdatedById { get; set; }
+    public bool IsDeleted { get; set; }
+    public DateTimeOffset? DeletedAt { get; set; }
+    public Guid? DeletedById { get; set; }
+}

--- a/src/Mazad.Domain/Common/BaseEntity.cs
+++ b/src/Mazad.Domain/Common/BaseEntity.cs
@@ -1,0 +1,6 @@
+namespace Mazad.Domain.Common;
+
+public abstract class BaseEntity
+{
+    public Guid Id { get; set; }
+}

--- a/src/Mazad.Domain/Entities/Bids/Bid.cs
+++ b/src/Mazad.Domain/Entities/Bids/Bid.cs
@@ -1,0 +1,16 @@
+using Mazad.Domain.Common;
+using Mazad.Domain.Entities.Listings;
+using Mazad.Domain.Enums;
+
+namespace Mazad.Domain.Entities.Bids;
+
+public class Bid : AuditableEntity
+{
+    public Guid ListingId { get; set; }
+    public Guid BidderId { get; set; }
+    public decimal Amount { get; set; }
+    public DateTimeOffset PlacedAt { get; set; }
+    public BidStatus Status { get; set; } = BidStatus.Placed;
+
+    public Listing? Listing { get; set; }
+}

--- a/src/Mazad.Domain/Entities/Catalog/AttributeDefinition.cs
+++ b/src/Mazad.Domain/Entities/Catalog/AttributeDefinition.cs
@@ -1,0 +1,14 @@
+using Mazad.Domain.Common;
+
+namespace Mazad.Domain.Entities.Catalog;
+
+public class AttributeDefinition : AuditableEntity
+{
+    public Guid CategoryId { get; set; }
+    public string Key { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string DataType { get; set; } = string.Empty;
+    public string? OptionsJson { get; set; }
+
+    public Category? Category { get; set; }
+}

--- a/src/Mazad.Domain/Entities/Catalog/Category.cs
+++ b/src/Mazad.Domain/Entities/Catalog/Category.cs
@@ -1,0 +1,16 @@
+using Mazad.Domain.Common;
+using Mazad.Domain.Entities.Listings;
+
+namespace Mazad.Domain.Entities.Catalog;
+
+public class Category : AuditableEntity
+{
+    public Guid? ParentId { get; set; }
+    public string Slug { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? AttributesSchema { get; set; }
+
+    public Category? Parent { get; set; }
+    public ICollection<Category> Children { get; set; } = new List<Category>();
+    public ICollection<Listing> Listings { get; set; } = new List<Listing>();
+}

--- a/src/Mazad.Domain/Entities/Cms/MediaAsset.cs
+++ b/src/Mazad.Domain/Entities/Cms/MediaAsset.cs
@@ -1,0 +1,13 @@
+using Mazad.Domain.Common;
+
+namespace Mazad.Domain.Entities.Cms;
+
+public class MediaAsset : AuditableEntity
+{
+    public string Url { get; set; } = string.Empty;
+    public string Mime { get; set; } = string.Empty;
+    public long Size { get; set; }
+    public string? Folder { get; set; }
+    public string? AltText { get; set; }
+    public string? Tags { get; set; }
+}

--- a/src/Mazad.Domain/Entities/Cms/Menu.cs
+++ b/src/Mazad.Domain/Entities/Cms/Menu.cs
@@ -1,0 +1,9 @@
+using Mazad.Domain.Common;
+
+namespace Mazad.Domain.Entities.Cms;
+
+public class Menu : AuditableEntity
+{
+    public string Key { get; set; } = string.Empty;
+    public string Items { get; set; } = string.Empty;
+}

--- a/src/Mazad.Domain/Entities/Cms/Page.cs
+++ b/src/Mazad.Domain/Entities/Cms/Page.cs
@@ -1,0 +1,16 @@
+using Mazad.Domain.Common;
+using Mazad.Domain.Enums;
+
+namespace Mazad.Domain.Entities.Cms;
+
+public class Page : AuditableEntity
+{
+    public string Slug { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Blocks { get; set; } = string.Empty;
+    public string? SeoTitle { get; set; }
+    public string? SeoDescription { get; set; }
+    public string? SeoImage { get; set; }
+    public PageStatus Status { get; set; } = PageStatus.Draft;
+    public DateTimeOffset? PublishedAt { get; set; }
+}

--- a/src/Mazad.Domain/Entities/Identity/UserProfile.cs
+++ b/src/Mazad.Domain/Entities/Identity/UserProfile.cs
@@ -1,0 +1,14 @@
+using Mazad.Domain.Common;
+
+namespace Mazad.Domain.Entities.Identity;
+
+public class UserProfile : AuditableEntity
+{
+    public Guid UserId { get; set; }
+    public string? AvatarUrl { get; set; }
+    public string? Address { get; set; }
+    public string? City { get; set; }
+    public string? Country { get; set; }
+    public string? Language { get; set; }
+    public string? Timezone { get; set; }
+}

--- a/src/Mazad.Domain/Entities/Listings/Listing.cs
+++ b/src/Mazad.Domain/Entities/Listings/Listing.cs
@@ -1,0 +1,33 @@
+using Mazad.Domain.Common;
+using Mazad.Domain.Entities.Bids;
+using Mazad.Domain.Entities.Catalog;
+using Mazad.Domain.Enums;
+
+namespace Mazad.Domain.Entities.Listings;
+
+public class Listing : AuditableEntity
+{
+    public Guid SellerId { get; set; }
+    public Guid CategoryId { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string? Location { get; set; }
+    public string? Attributes { get; set; }
+    public ListingType Type { get; set; }
+    public ListingStatus Status { get; set; } = ListingStatus.Draft;
+    public DateTimeOffset? StartAt { get; set; }
+    public DateTimeOffset? EndAt { get; set; }
+    public decimal? StartPrice { get; set; }
+    public decimal? ReservePrice { get; set; }
+    public decimal? BidIncrement { get; set; }
+    public decimal? BuyNowPrice { get; set; }
+    public int Views { get; set; }
+    public int WatchCount { get; set; }
+    public string? ModerationNotes { get; set; }
+    public string? RejectionReason { get; set; }
+
+    public Category? Category { get; set; }
+    public ICollection<ListingMedia> Media { get; set; } = new List<ListingMedia>();
+    public ICollection<Bid> Bids { get; set; } = new List<Bid>();
+}

--- a/src/Mazad.Domain/Entities/Listings/ListingMedia.cs
+++ b/src/Mazad.Domain/Entities/Listings/ListingMedia.cs
@@ -1,0 +1,14 @@
+using Mazad.Domain.Common;
+
+namespace Mazad.Domain.Entities.Listings;
+
+public class ListingMedia : AuditableEntity
+{
+    public Guid ListingId { get; set; }
+    public string Url { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
+    public bool IsCover { get; set; }
+
+    public Listing? Listing { get; set; }
+}

--- a/src/Mazad.Domain/Entities/Orders/Order.cs
+++ b/src/Mazad.Domain/Entities/Orders/Order.cs
@@ -1,0 +1,14 @@
+using Mazad.Domain.Common;
+using Mazad.Domain.Enums;
+
+namespace Mazad.Domain.Entities.Orders;
+
+public class Order : AuditableEntity
+{
+    public Guid ListingId { get; set; }
+    public Guid BuyerId { get; set; }
+    public Guid SellerId { get; set; }
+    public decimal Price { get; set; }
+    public OrderStatus Status { get; set; } = OrderStatus.Pending;
+    public DateTimeOffset CreatedAtUtc { get; set; }
+}

--- a/src/Mazad.Domain/Entities/Taxonomy/VehicleBrand.cs
+++ b/src/Mazad.Domain/Entities/Taxonomy/VehicleBrand.cs
@@ -1,0 +1,11 @@
+using Mazad.Domain.Common;
+
+namespace Mazad.Domain.Entities.Taxonomy;
+
+public class VehicleBrand : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+
+    public ICollection<VehicleModel> Models { get; set; } = new List<VehicleModel>();
+}

--- a/src/Mazad.Domain/Entities/Taxonomy/VehicleModel.cs
+++ b/src/Mazad.Domain/Entities/Taxonomy/VehicleModel.cs
@@ -1,0 +1,13 @@
+using Mazad.Domain.Common;
+
+namespace Mazad.Domain.Entities.Taxonomy;
+
+public class VehicleModel : AuditableEntity
+{
+    public Guid BrandId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+
+    public VehicleBrand? Brand { get; set; }
+    public ICollection<VehicleTrim> Trims { get; set; } = new List<VehicleTrim>();
+}

--- a/src/Mazad.Domain/Entities/Taxonomy/VehicleTrim.cs
+++ b/src/Mazad.Domain/Entities/Taxonomy/VehicleTrim.cs
@@ -1,0 +1,11 @@
+using Mazad.Domain.Common;
+
+namespace Mazad.Domain.Entities.Taxonomy;
+
+public class VehicleTrim : AuditableEntity
+{
+    public Guid ModelId { get; set; }
+    public string Name { get; set; } = string.Empty;
+
+    public VehicleModel? Model { get; set; }
+}

--- a/src/Mazad.Domain/Entities/Taxonomy/YearRange.cs
+++ b/src/Mazad.Domain/Entities/Taxonomy/YearRange.cs
@@ -1,0 +1,9 @@
+using Mazad.Domain.Common;
+
+namespace Mazad.Domain.Entities.Taxonomy;
+
+public class YearRange : AuditableEntity
+{
+    public int StartYear { get; set; }
+    public int EndYear { get; set; }
+}

--- a/src/Mazad.Domain/Entities/Watchlists/WatchlistItem.cs
+++ b/src/Mazad.Domain/Entities/Watchlists/WatchlistItem.cs
@@ -1,0 +1,9 @@
+using Mazad.Domain.Common;
+
+namespace Mazad.Domain.Entities.Watchlists;
+
+public class WatchlistItem : AuditableEntity
+{
+    public Guid UserId { get; set; }
+    public Guid ListingId { get; set; }
+}

--- a/src/Mazad.Domain/Enums/BidStatus.cs
+++ b/src/Mazad.Domain/Enums/BidStatus.cs
@@ -1,0 +1,10 @@
+namespace Mazad.Domain.Enums;
+
+public enum BidStatus
+{
+    Placed = 1,
+    Winning = 2,
+    Outbid = 3,
+    Retracted = 4,
+    Invalid = 5
+}

--- a/src/Mazad.Domain/Enums/KycStatus.cs
+++ b/src/Mazad.Domain/Enums/KycStatus.cs
@@ -1,0 +1,9 @@
+namespace Mazad.Domain.Enums;
+
+public enum KycStatus
+{
+    None = 0,
+    Pending = 1,
+    Verified = 2,
+    Rejected = 3
+}

--- a/src/Mazad.Domain/Enums/ListingStatus.cs
+++ b/src/Mazad.Domain/Enums/ListingStatus.cs
@@ -1,0 +1,14 @@
+namespace Mazad.Domain.Enums;
+
+public enum ListingStatus
+{
+    Draft = 1,
+    PendingReview = 2,
+    Rejected = 3,
+    Approved = 4,
+    Active = 5,
+    Paused = 6,
+    Sold = 7,
+    Expired = 8,
+    Cancelled = 9
+}

--- a/src/Mazad.Domain/Enums/ListingType.cs
+++ b/src/Mazad.Domain/Enums/ListingType.cs
@@ -1,0 +1,8 @@
+namespace Mazad.Domain.Enums;
+
+public enum ListingType
+{
+    Auction = 1,
+    BuyNow = 2,
+    Both = 3
+}

--- a/src/Mazad.Domain/Enums/OrderStatus.cs
+++ b/src/Mazad.Domain/Enums/OrderStatus.cs
@@ -1,0 +1,10 @@
+namespace Mazad.Domain.Enums;
+
+public enum OrderStatus
+{
+    Pending = 1,
+    Paid = 2,
+    Cancelled = 3,
+    Failed = 4,
+    Refunded = 5
+}

--- a/src/Mazad.Domain/Enums/PageStatus.cs
+++ b/src/Mazad.Domain/Enums/PageStatus.cs
@@ -1,0 +1,8 @@
+namespace Mazad.Domain.Enums;
+
+public enum PageStatus
+{
+    Draft = 1,
+    Published = 2,
+    Archived = 3
+}

--- a/src/Mazad.Domain/Mazad.Domain.csproj
+++ b/src/Mazad.Domain/Mazad.Domain.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/Mazad.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mazad.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,94 @@
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Infrastructure.Identity;
+using Mazad.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mazad.Infrastructure.DependencyInjection;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection")
+            ?? configuration["Database:ConnectionString"]
+            ?? "Server=(localdb)\\mssqllocaldb;Database=MazadDb;Trusted_Connection=True;MultipleActiveResultSets=true";
+
+        services.AddDbContext<MazadDbContext>(options =>
+        {
+            options.UseSqlServer(connectionString, sql =>
+            {
+                sql.MigrationsAssembly(typeof(MazadDbContext).Assembly.FullName);
+            });
+            options.UseOpenIddict();
+        });
+
+        services.AddScoped<IMazadDbContext>(sp => sp.GetRequiredService<MazadDbContext>());
+
+        services.AddIdentity<ApplicationUser, ApplicationRole>(options =>
+            {
+                options.Password.RequireDigit = true;
+                options.Password.RequireUppercase = false;
+                options.Password.RequireLowercase = false;
+                options.Password.RequireNonAlphanumeric = false;
+                options.Password.RequiredLength = 6;
+            })
+            .AddEntityFrameworkStores<MazadDbContext>()
+            .AddDefaultTokenProviders();
+
+        services.AddOpenIddict()
+            .AddCore(builder =>
+            {
+                builder.UseEntityFrameworkCore()
+                    .UseDbContext<MazadDbContext>();
+            })
+            .AddServer(builder =>
+            {
+                builder.SetAuthorizationEndpointUris("/connect/authorize")
+                    .SetTokenEndpointUris("/connect/token")
+                    .AllowAuthorizationCodeFlow()
+                    .RequireProofKeyForCodeExchange()
+                    .AllowRefreshTokenFlow();
+
+                builder.RegisterScopes(
+                    "openid",
+                    "profile",
+                    "email",
+                    "roles",
+                    "mazad.api",
+                    "mazad.admin",
+                    "mazad.seller",
+                    "mazad.bidder",
+                    "mazad.cms",
+                    "offline_access");
+
+                builder.UseAspNetCore()
+                    .EnableAuthorizationEndpointPassthrough()
+                    .EnableTokenEndpointPassthrough();
+            })
+            .AddValidation(options =>
+            {
+                options.UseLocalServer();
+                options.UseAspNetCore();
+            });
+
+        services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = IdentityConstants.ApplicationScheme;
+                options.DefaultChallengeScheme = IdentityConstants.ApplicationScheme;
+            })
+            .AddIdentityCookies();
+
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy("Scope:mazad.admin", policy => policy.RequireClaim("scope", "mazad.admin"));
+            options.AddPolicy("Scope:mazad.seller", policy => policy.RequireClaim("scope", "mazad.seller"));
+            options.AddPolicy("Scope:mazad.bidder", policy => policy.RequireClaim("scope", "mazad.bidder"));
+            options.AddPolicy("Scope:mazad.cms", policy => policy.RequireClaim("scope", "mazad.cms"));
+        });
+
+        return services;
+    }
+}

--- a/src/Mazad.Infrastructure/Identity/ApplicationRole.cs
+++ b/src/Mazad.Infrastructure/Identity/ApplicationRole.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace Mazad.Infrastructure.Identity;
+
+public class ApplicationRole : IdentityRole<Guid>
+{
+    public ApplicationRole()
+    {
+    }
+
+    public ApplicationRole(string name) : base(name)
+    {
+    }
+}

--- a/src/Mazad.Infrastructure/Identity/ApplicationUser.cs
+++ b/src/Mazad.Infrastructure/Identity/ApplicationUser.cs
@@ -1,0 +1,13 @@
+using Mazad.Domain.Entities.Identity;
+using Mazad.Domain.Enums;
+using Microsoft.AspNetCore.Identity;
+
+namespace Mazad.Infrastructure.Identity;
+
+public class ApplicationUser : IdentityUser<Guid>
+{
+    public string? FullName { get; set; }
+    public KycStatus KycStatus { get; set; } = KycStatus.None;
+    public bool IsDeleted { get; set; }
+    public UserProfile? Profile { get; set; }
+}

--- a/src/Mazad.Infrastructure/Mazad.Infrastructure.csproj
+++ b/src/Mazad.Infrastructure/Mazad.Infrastructure.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.5" />
+    <PackageReference Include="OpenIddict" Version="4.9.0" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.9.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mazad.Application\Mazad.Application.csproj" />
+    <ProjectReference Include="..\Mazad.Domain\Mazad.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Mazad.Infrastructure/Persistence/MazadDbContext.cs
+++ b/src/Mazad.Infrastructure/Persistence/MazadDbContext.cs
@@ -1,0 +1,128 @@
+using Mazad.Application.Abstractions.Persistence;
+using Mazad.Domain.Entities.Bids;
+using Mazad.Domain.Entities.Catalog;
+using Mazad.Domain.Entities.Cms;
+using Mazad.Domain.Entities.Identity;
+using Mazad.Domain.Entities.Listings;
+using Mazad.Domain.Entities.Orders;
+using Mazad.Domain.Entities.Taxonomy;
+using Mazad.Domain.Entities.Watchlists;
+using Mazad.Infrastructure.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mazad.Infrastructure.Persistence;
+
+public class MazadDbContext : IdentityDbContext<ApplicationUser, ApplicationRole, Guid>, IMazadDbContext
+{
+    public MazadDbContext(DbContextOptions<MazadDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Category> Categories => Set<Category>();
+    public DbSet<AttributeDefinition> AttributeDefinitions => Set<AttributeDefinition>();
+    public DbSet<VehicleBrand> VehicleBrands => Set<VehicleBrand>();
+    public DbSet<VehicleModel> VehicleModels => Set<VehicleModel>();
+    public DbSet<VehicleTrim> VehicleTrims => Set<VehicleTrim>();
+    public DbSet<YearRange> YearRanges => Set<YearRange>();
+    public DbSet<Listing> Listings => Set<Listing>();
+    public DbSet<ListingMedia> ListingMedia => Set<ListingMedia>();
+    public DbSet<Bid> Bids => Set<Bid>();
+    public DbSet<WatchlistItem> Watchlists => Set<WatchlistItem>();
+    public DbSet<Order> Orders => Set<Order>();
+    public DbSet<Page> Pages => Set<Page>();
+    public DbSet<Menu> Menus => Set<Menu>();
+    public DbSet<MediaAsset> MediaAssets => Set<MediaAsset>();
+    public DbSet<UserProfile> UserProfiles => Set<UserProfile>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+
+        builder.Entity<Category>(entity =>
+        {
+            entity.HasIndex(e => e.Slug).IsUnique();
+            entity.HasOne(e => e.Parent)
+                .WithMany(e => e.Children)
+                .HasForeignKey(e => e.ParentId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        builder.Entity<Listing>(entity =>
+        {
+            entity.HasIndex(e => e.Slug).IsUnique();
+            entity.Property(e => e.StartPrice).HasColumnType("decimal(18,2)");
+            entity.Property(e => e.ReservePrice).HasColumnType("decimal(18,2)");
+            entity.Property(e => e.BidIncrement).HasColumnType("decimal(18,2)");
+            entity.Property(e => e.BuyNowPrice).HasColumnType("decimal(18,2)");
+            entity.HasMany(e => e.Media)
+                .WithOne(m => m.Listing)
+                .HasForeignKey(m => m.ListingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasMany(e => e.Bids)
+                .WithOne(b => b.Listing)
+                .HasForeignKey(b => b.ListingId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        builder.Entity<ListingMedia>(entity =>
+        {
+            entity.Property(e => e.Url).HasMaxLength(2048);
+        });
+
+        builder.Entity<Bid>(entity =>
+        {
+            entity.Property(e => e.Amount).HasColumnType("decimal(18,2)");
+        });
+
+        builder.Entity<WatchlistItem>(entity =>
+        {
+            entity.HasIndex(e => new { e.UserId, e.ListingId }).IsUnique();
+        });
+
+        builder.Entity<Page>(entity =>
+        {
+            entity.HasIndex(e => e.Slug).IsUnique();
+        });
+
+        builder.Entity<Menu>(entity =>
+        {
+            entity.HasIndex(e => e.Key).IsUnique();
+        });
+
+        builder.Entity<ApplicationUser>(entity =>
+        {
+            entity.HasOne(e => e.Profile)
+                .WithOne()
+                .HasForeignKey<UserProfile>(p => p.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        builder.Entity<UserProfile>(entity =>
+        {
+            entity.Property(e => e.AvatarUrl).HasMaxLength(2048);
+        });
+    }
+
+    public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        foreach (var entry in ChangeTracker.Entries())
+        {
+            if (entry.Entity is Domain.Common.AuditableEntity auditable)
+            {
+                var now = DateTimeOffset.UtcNow;
+                if (entry.State == EntityState.Added)
+                {
+                    auditable.CreatedAt = now;
+                }
+                else if (entry.State == EntityState.Modified)
+                {
+                    auditable.UpdatedAt = now;
+                }
+            }
+        }
+
+        return await base.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Mazad.Infrastructure/Persistence/Migrations/20240607000000_InitialCreate.cs
+++ b/src/Mazad.Infrastructure/Persistence/Migrations/20240607000000_InitialCreate.cs
@@ -1,0 +1,897 @@
+#nullable disable
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Mazad.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class InitialCreate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AspNetRoles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUsers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    FullName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    KycStatus = table.Column<int>(type: "int", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    UserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedUserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    Email = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedEmail = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    EmailConfirmed = table.Column<bool>(type: "bit", nullable: false),
+                    PasswordHash = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    SecurityStamp = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PhoneNumber = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PhoneNumberConfirmed = table.Column<bool>(type: "bit", nullable: false),
+                    TwoFactorEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    LockoutEnd = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LockoutEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    AccessFailedCount = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUsers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Categories",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ParentId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Slug = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    AttributesSchema = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Categories", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Categories_Categories_ParentId",
+                        column: x => x.ParentId,
+                        principalTable: "Categories",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MediaAssets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Url = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Mime = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Size = table.Column<long>(type: "bigint", nullable: false),
+                    Folder = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    AltText = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Tags = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MediaAssets", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Menus",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Items = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Menus", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OpenIddictApplications",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ClientId = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    ClientSecret = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ConsentType = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    DisplayName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    DisplayNames = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Permissions = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PostLogoutRedirectUris = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Properties = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    RedirectUris = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Requirements = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Type = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    ConcurrencyToken = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OpenIddictApplications", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OpenIddictScopes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Descriptions = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    DisplayName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    DisplayNames = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Properties = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ConcurrencyToken = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OpenIddictScopes", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Pages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Slug = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Blocks = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    SeoTitle = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    SeoDescription = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    SeoImage = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    PublishedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Pages", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VehicleBrands",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Slug = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VehicleBrands", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "YearRanges",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    StartYear = table.Column<int>(type: "int", nullable: false),
+                    EndYear = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_YearRanges", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetRoleClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    RoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ClaimType = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ClaimValue = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoleClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetRoleClaims_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ClaimType = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ClaimValue = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserClaims_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserLogins",
+                columns: table => new
+                {
+                    LoginProvider = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ProviderKey = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ProviderDisplayName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserLogins", x => new { x.LoginProvider, x.ProviderKey });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserLogins_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserRoles",
+                columns: table => new
+                {
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserRoles", x => new { x.UserId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserTokens",
+                columns: table => new
+                {
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LoginProvider = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserTokens", x => new { x.UserId, x.LoginProvider, x.Name });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserTokens_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OpenIddictAuthorizations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ApplicationId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    Subject = table.Column<string>(type: "nvarchar(400)", maxLength: 400, nullable: true),
+                    Type = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    CreationDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    ExpirationDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    Properties = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Scopes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ConcurrencyToken = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OpenIddictAuthorizations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OpenIddictAuthorizations_OpenIddictApplications_ApplicationId",
+                        column: x => x.ApplicationId,
+                        principalTable: "OpenIddictApplications",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AvatarUrl = table.Column<string>(type: "nvarchar(2048)", maxLength: 2048, nullable: true),
+                    Address = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    City = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Country = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Language = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Timezone = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserProfiles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserProfiles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AttributeDefinitions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CategoryId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    DisplayName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    DataType = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    OptionsJson = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AttributeDefinitions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AttributeDefinitions_Categories_CategoryId",
+                        column: x => x.CategoryId,
+                        principalTable: "Categories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VehicleModels",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    BrandId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Slug = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VehicleModels", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VehicleModels_VehicleBrands_BrandId",
+                        column: x => x.BrandId,
+                        principalTable: "VehicleBrands",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Listings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SellerId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CategoryId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Slug = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Location = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Attributes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Type = table.Column<int>(type: "int", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    StartAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    EndAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    StartPrice = table.Column<decimal>(type: "decimal(18,2)", nullable: true),
+                    ReservePrice = table.Column<decimal>(type: "decimal(18,2)", nullable: true),
+                    BidIncrement = table.Column<decimal>(type: "decimal(18,2)", nullable: true),
+                    BuyNowPrice = table.Column<decimal>(type: "decimal(18,2)", nullable: true),
+                    Views = table.Column<int>(type: "int", nullable: false),
+                    WatchCount = table.Column<int>(type: "int", nullable: false),
+                    ModerationNotes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    RejectionReason = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Listings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Listings_Categories_CategoryId",
+                        column: x => x.CategoryId,
+                        principalTable: "Categories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VehicleTrims",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ModelId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VehicleTrims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VehicleTrims_VehicleModels_ModelId",
+                        column: x => x.ModelId,
+                        principalTable: "VehicleModels",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ListingMedia",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ListingId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Url = table.Column<string>(type: "nvarchar(2048)", maxLength: 2048, nullable: false),
+                    Type = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    SortOrder = table.Column<int>(type: "int", nullable: false),
+                    IsCover = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ListingMedia", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ListingMedia_Listings_ListingId",
+                        column: x => x.ListingId,
+                        principalTable: "Listings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Bids",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ListingId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    BidderId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Amount = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    PlacedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Bids", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Bids_Listings_ListingId",
+                        column: x => x.ListingId,
+                        principalTable: "Listings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OpenIddictTokens",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ApplicationId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    AuthorizationId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    Subject = table.Column<string>(type: "nvarchar(400)", maxLength: 400, nullable: true),
+                    Type = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    CreationDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    ExpirationDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    Payload = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Properties = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    RedemptionDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    ReferenceId = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    ConcurrencyToken = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OpenIddictTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OpenIddictTokens_OpenIddictApplications_ApplicationId",
+                        column: x => x.ApplicationId,
+                        principalTable: "OpenIddictApplications",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_OpenIddictTokens_OpenIddictAuthorizations_AuthorizationId",
+                        column: x => x.AuthorizationId,
+                        principalTable: "OpenIddictAuthorizations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Orders",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ListingId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    BuyerId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SellerId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Price = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    CreatedAtUtc = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orders", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WatchlistItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ListingId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WatchlistItems", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetRoleClaims_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "RoleNameIndex",
+                table: "AspNetRoles",
+                column: "NormalizedName",
+                unique: true,
+                filter: "[NormalizedName] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserClaims_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserLogins_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserRoles_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "EmailIndex",
+                table: "AspNetUsers",
+                column: "NormalizedEmail");
+
+            migrationBuilder.CreateIndex(
+                name: "UserNameIndex",
+                table: "AspNetUsers",
+                column: "NormalizedUserName",
+                unique: true,
+                filter: "[NormalizedUserName] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AttributeDefinitions_CategoryId",
+                table: "AttributeDefinitions",
+                column: "CategoryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Bids_ListingId",
+                table: "Bids",
+                column: "ListingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Categories_ParentId",
+                table: "Categories",
+                column: "ParentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Categories_Slug",
+                table: "Categories",
+                column: "Slug",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ListingMedia_ListingId",
+                table: "ListingMedia",
+                column: "ListingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Listings_CategoryId",
+                table: "Listings",
+                column: "CategoryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Listings_Slug",
+                table: "Listings",
+                column: "Slug",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Menus_Key",
+                table: "Menus",
+                column: "Key",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OpenIddictApplications_ClientId",
+                table: "OpenIddictApplications",
+                column: "ClientId",
+                unique: true,
+                filter: "[ClientId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OpenIddictAuthorizations_ApplicationId",
+                table: "OpenIddictAuthorizations",
+                column: "ApplicationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OpenIddictAuthorizations_ApplicationId_Status_Subject_Type",
+                table: "OpenIddictAuthorizations",
+                columns: new[] { "ApplicationId", "Status", "Subject", "Type" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OpenIddictScopes_Name",
+                table: "OpenIddictScopes",
+                column: "Name",
+                unique: true,
+                filter: "[Name] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OpenIddictTokens_ApplicationId",
+                table: "OpenIddictTokens",
+                column: "ApplicationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OpenIddictTokens_AuthorizationId",
+                table: "OpenIddictTokens",
+                column: "AuthorizationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OpenIddictTokens_ApplicationId_Status_Subject_Type",
+                table: "OpenIddictTokens",
+                columns: new[] { "ApplicationId", "Status", "Subject", "Type" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OpenIddictTokens_ReferenceId",
+                table: "OpenIddictTokens",
+                column: "ReferenceId",
+                unique: true,
+                filter: "[ReferenceId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Pages_Slug",
+                table: "Pages",
+                column: "Slug",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserProfiles_UserId",
+                table: "UserProfiles",
+                column: "UserId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VehicleModels_BrandId",
+                table: "VehicleModels",
+                column: "BrandId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VehicleTrims_ModelId",
+                table: "VehicleTrims",
+                column: "ModelId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WatchlistItems_UserId_ListingId",
+                table: "WatchlistItems",
+                columns: new[] { "UserId", "ListingId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AspNetRoleClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserLogins");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserTokens");
+
+            migrationBuilder.DropTable(
+                name: "AttributeDefinitions");
+
+            migrationBuilder.DropTable(
+                name: "Bids");
+
+            migrationBuilder.DropTable(
+                name: "ListingMedia");
+
+            migrationBuilder.DropTable(
+                name: "Menus");
+
+            migrationBuilder.DropTable(
+                name: "MediaAssets");
+
+            migrationBuilder.DropTable(
+                name: "OpenIddictTokens");
+
+            migrationBuilder.DropTable(
+                name: "Orders");
+
+            migrationBuilder.DropTable(
+                name: "Pages");
+
+            migrationBuilder.DropTable(
+                name: "UserProfiles");
+
+            migrationBuilder.DropTable(
+                name: "VehicleTrims");
+
+            migrationBuilder.DropTable(
+                name: "WatchlistItems");
+
+            migrationBuilder.DropTable(
+                name: "OpenIddictAuthorizations");
+
+            migrationBuilder.DropTable(
+                name: "Listings");
+
+            migrationBuilder.DropTable(
+                name: "VehicleModels");
+
+            migrationBuilder.DropTable(
+                name: "AspNetRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUsers");
+
+            migrationBuilder.DropTable(
+                name: "OpenIddictApplications");
+
+            migrationBuilder.DropTable(
+                name: "OpenIddictScopes");
+
+            migrationBuilder.DropTable(
+                name: "Categories");
+
+            migrationBuilder.DropTable(
+                name: "VehicleBrands");
+
+            migrationBuilder.DropTable(
+                name: "YearRanges");
+        }
+    }
+}

--- a/src/Mazad.Infrastructure/Persistence/Migrations/MazadDbContextModelSnapshot.cs
+++ b/src/Mazad.Infrastructure/Persistence/Migrations/MazadDbContextModelSnapshot.cs
@@ -1,0 +1,1388 @@
+#nullable disable
+using System;
+using Mazad.Infrastructure.Identity;
+using Mazad.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using OpenIddict.EntityFrameworkCore.Models;
+
+namespace Mazad.Infrastructure.Persistence.Migrations
+{
+    [DbContext(typeof(MazadDbContext))]
+    partial class MazadDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasAnnotation("ProductVersion", "8.0.5")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Bids.Bid", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<decimal>("Amount")
+                        .HasColumnType("decimal(18,2)");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<Guid>("ListingId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid>("BidderId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("PlacedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ListingId");
+
+                    b.ToTable("Bids");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Catalog.AttributeDefinition", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("DataType")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("DisplayName")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Key")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("CategoryId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("OptionsJson")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CategoryId");
+
+                    b.ToTable("AttributeDefinitions");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Catalog.Category", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("AttributesSchema")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("ParentId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Slug")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ParentId");
+
+                    b.HasIndex("Slug")
+                        .IsUnique();
+
+                    b.ToTable("Categories");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Cms.MediaAsset", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("AltText")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("Folder")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Mime")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<long>("Size")
+                        .HasColumnType("bigint");
+
+                    b.Property<string>("Tags")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Url")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("MediaAssets");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Cms.Menu", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Items")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Key")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Key")
+                        .IsUnique();
+
+                    b.ToTable("Menus");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Cms.Page", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Blocks")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<DateTimeOffset?>("PublishedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
+
+                    b.Property<string>("SeoDescription")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("SeoImage")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("SeoTitle")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Slug")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<string>("Title")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Slug")
+                        .IsUnique();
+
+                    b.ToTable("Pages");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Identity.UserProfile", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Address")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("AvatarUrl")
+                        .HasMaxLength(2048)
+                        .HasColumnType("nvarchar(2048)");
+
+                    b.Property<string>("City")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Country")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("Language")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Timezone")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId")
+                        .IsUnique();
+
+                    b.ToTable("UserProfiles");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Listings.Listing", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Attributes")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<decimal?>("BidIncrement")
+                        .HasColumnType("decimal(18,2)");
+
+                    b.Property<decimal?>("BuyNowPrice")
+                        .HasColumnType("decimal(18,2)");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid>("CategoryId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTimeOffset?>("EndAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Location")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("ModerationNotes")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<decimal?>("ReservePrice")
+                        .HasColumnType("decimal(18,2)");
+
+                    b.Property<string>("RejectionReason")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("SellerId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Slug")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<DateTimeOffset?>("StartAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<decimal?>("StartPrice")
+                        .HasColumnType("decimal(18,2)");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
+
+                    b.Property<string>("Title")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<int>("Type")
+                        .HasColumnType("int");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<int>("Views")
+                        .HasColumnType("int");
+
+                    b.Property<int>("WatchCount")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CategoryId");
+
+                    b.HasIndex("Slug")
+                        .IsUnique();
+
+                    b.ToTable("Listings");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Listings.ListingMedia", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsCover")
+                        .HasColumnType("bit");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<Guid>("ListingId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<int>("SortOrder")
+                        .HasColumnType("int");
+
+                    b.Property<string>("Type")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("Url")
+                        .IsRequired()
+                        .HasMaxLength(2048)
+                        .HasColumnType("nvarchar(2048)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ListingId");
+
+                    b.ToTable("ListingMedia");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Orders.Order", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid>("BuyerId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<DateTimeOffset>("CreatedAtUtc")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<Guid>("ListingId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<decimal>("Price")
+                        .HasColumnType("decimal(18,2)");
+
+                    b.Property<Guid>("SellerId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Orders");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Taxonomy.VehicleBrand", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Slug")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("VehicleBrands");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Taxonomy.VehicleBrand", b =>
+                {
+                    b.Navigation("Models");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Taxonomy.VehicleModel", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid>("BrandId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Slug")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("BrandId");
+
+                    b.ToTable("VehicleModels");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Taxonomy.VehicleModel", b =>
+                {
+                    b.Navigation("Trims");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Taxonomy.VehicleTrim", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<Guid>("ModelId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ModelId");
+
+                    b.ToTable("VehicleTrims");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Taxonomy.YearRange", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<int>("EndYear")
+                        .HasColumnType("int");
+
+                    b.Property<int>("StartYear")
+                        .HasColumnType("int");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("YearRanges");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Watchlists.WatchlistItem", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid?>("DeletedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("DeletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<Guid>("ListingId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId", "ListingId")
+                        .IsUnique();
+
+                    b.ToTable("WatchlistItems");
+                });
+
+            modelBuilder.Entity("Mazad.Infrastructure.Identity.ApplicationRole", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<string>("NormalizedName")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedName")
+                        .IsUnique()
+                        .HasDatabaseName("RoleNameIndex")
+                        .HasFilter("[NormalizedName] IS NOT NULL");
+
+                    b.ToTable("AspNetRoles", (string)null);
+                });
+
+            modelBuilder.Entity("Mazad.Infrastructure.Identity.ApplicationUser", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<int>("AccessFailedCount")
+                        .HasColumnType("int");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Email")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<bool>("EmailConfirmed")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("FullName")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<int>("KycStatus")
+                        .HasColumnType("int");
+
+                    b.Property<bool>("LockoutEnabled")
+                        .HasColumnType("bit");
+
+                    b.Property<DateTimeOffset?>("LockoutEnd")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("NormalizedEmail")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<string>("NormalizedUserName")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<string>("PasswordHash")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("PhoneNumber")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<bool>("PhoneNumberConfirmed")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("SecurityStamp")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<bool>("TwoFactorEnabled")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("UserName")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedEmail")
+                        .HasDatabaseName("EmailIndex");
+
+                    b.HasIndex("NormalizedUserName")
+                        .IsUnique()
+                        .HasDatabaseName("UserNameIndex")
+                        .HasFilter("[NormalizedUserName] IS NOT NULL");
+
+                    b.ToTable("AspNetUsers", (string)null);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<Guid>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
+
+                    b.Property<string>("ClaimType")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("ClaimValue")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("RoleId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("RoleId");
+
+                    b.ToTable("AspNetRoleClaims", (string)null);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<Guid>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
+
+                    b.Property<string>("ClaimType")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("ClaimValue")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("AspNetUserClaims", (string)null);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<Guid>", b =>
+                {
+                    b.Property<string>("LoginProvider")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<string>("ProviderKey")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<string>("ProviderDisplayName")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("LoginProvider", "ProviderKey");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("AspNetUserLogins", (string)null);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<Guid>", b =>
+                {
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid>("RoleId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("UserId", "RoleId");
+
+                    b.HasIndex("RoleId");
+
+                    b.ToTable("AspNetUserRoles", (string)null);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<Guid>", b =>
+                {
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("LoginProvider")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<string>("Name")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<string>("Value")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("UserId", "LoginProvider", "Name");
+
+                    b.ToTable("AspNetUserTokens", (string)null);
+                });
+
+            modelBuilder.Entity("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreApplication<Guid>", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("ClientId")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b.Property<string>("ClientSecret")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("ConsentType")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.Property<string>("DisplayNames")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Permissions")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("PostLogoutRedirectUris")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Properties")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("RedirectUris")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Requirements")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("ConcurrencyToken")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b.Property<string>("Type")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ClientId")
+                        .IsUnique()
+                        .HasFilter("[ClientId] IS NOT NULL");
+
+                    b.ToTable("OpenIddictApplications", (string)null);
+                });
+
+            modelBuilder.Entity("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreApplication<Guid>", b =>
+                {
+                    b.Navigation("Authorizations");
+
+                    b.Navigation("Tokens");
+                });
+
+            modelBuilder.Entity("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreAuthorization<Guid>", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("ApplicationId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("ConcurrencyToken")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b.Property<DateTimeOffset?>("CreationDate")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<DateTimeOffset?>("ExpirationDate")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("Properties")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Scopes")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Status")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b.Property<string>("Subject")
+                        .HasMaxLength(400)
+                        .HasColumnType("nvarchar(400)");
+
+                    b.Property<string>("Type")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ApplicationId");
+
+                    b.HasIndex("ApplicationId", "Status", "Subject", "Type");
+
+                    b.ToTable("OpenIddictAuthorizations", (string)null);
+                });
+
+            modelBuilder.Entity("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreAuthorization<Guid>", b =>
+                {
+                    b.Navigation("Tokens");
+                });
+
+            modelBuilder.Entity("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreScope<Guid>", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("ConcurrencyToken")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b.Property<string>("Description")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Descriptions")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.Property<string>("DisplayNames")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.Property<string>("Properties")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Name")
+                        .IsUnique()
+                        .HasFilter("[Name] IS NOT NULL");
+
+                    b.ToTable("OpenIddictScopes", (string)null);
+                });
+
+            modelBuilder.Entity("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreToken<Guid>", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("ApplicationId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid?>("AuthorizationId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("ConcurrencyToken")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b.Property<DateTimeOffset?>("CreationDate")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<DateTimeOffset?>("ExpirationDate")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("Payload")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Properties")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTimeOffset?>("RedemptionDate")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("ReferenceId")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b.Property<string>("Status")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b.Property<string>("Subject")
+                        .HasMaxLength(400)
+                        .HasColumnType("nvarchar(400)");
+
+                    b.Property<string>("Type")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ApplicationId");
+
+                    b.HasIndex("AuthorizationId");
+
+                    b.HasIndex("ApplicationId", "Status", "Subject", "Type");
+
+                    b.HasIndex("ReferenceId")
+                        .IsUnique()
+                        .HasFilter("[ReferenceId] IS NOT NULL");
+
+                    b.ToTable("OpenIddictTokens", (string)null);
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Catalog.Category", b =>
+                {
+                    b.HasOne("Mazad.Domain.Entities.Catalog.Category", "Parent")
+                        .WithMany("Children")
+                        .HasForeignKey("ParentId");
+
+                    b.Navigation("Children");
+
+                    b.Navigation("Listings");
+
+                    b.Navigation("Parent");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Listings.Listing", b =>
+                {
+                    b.HasOne("Mazad.Domain.Entities.Catalog.Category", "Category")
+                        .WithMany("Listings")
+                        .HasForeignKey("CategoryId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Category");
+
+                    b.Navigation("Bids");
+
+                    b.Navigation("Media");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Listings.ListingMedia", b =>
+                {
+                    b.HasOne("Mazad.Domain.Entities.Listings.Listing", "Listing")
+                        .WithMany("Media")
+                        .HasForeignKey("ListingId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Listing");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Bids.Bid", b =>
+                {
+                    b.HasOne("Mazad.Domain.Entities.Listings.Listing", "Listing")
+                        .WithMany("Bids")
+                        .HasForeignKey("ListingId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Listing");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Identity.UserProfile", b =>
+                {
+                    b.HasOne("Mazad.Infrastructure.Identity.ApplicationUser", null)
+                        .WithOne("Profile")
+                        .HasForeignKey("Mazad.Domain.Entities.Identity.UserProfile", "UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Taxonomy.VehicleModel", b =>
+                {
+                    b.HasOne("Mazad.Domain.Entities.Taxonomy.VehicleBrand", "Brand")
+                        .WithMany("Models")
+                        .HasForeignKey("BrandId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Brand");
+                });
+
+            modelBuilder.Entity("Mazad.Domain.Entities.Taxonomy.VehicleTrim", b =>
+                {
+                    b.HasOne("Mazad.Domain.Entities.Taxonomy.VehicleModel", "Model")
+                        .WithMany("Trims")
+                        .HasForeignKey("ModelId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Model");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<Guid>", b =>
+                {
+                    b.HasOne("Mazad.Infrastructure.Identity.ApplicationRole", null)
+                        .WithMany()
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<Guid>", b =>
+                {
+                    b.HasOne("Mazad.Infrastructure.Identity.ApplicationUser", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<Guid>", b =>
+                {
+                    b.HasOne("Mazad.Infrastructure.Identity.ApplicationUser", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<Guid>", b =>
+                {
+                    b.HasOne("Mazad.Infrastructure.Identity.ApplicationRole", null)
+                        .WithMany()
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("Mazad.Infrastructure.Identity.ApplicationUser", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<Guid>", b =>
+                {
+                    b.HasOne("Mazad.Infrastructure.Identity.ApplicationUser", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
+            modelBuilder.Entity("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreAuthorization<Guid>", b =>
+                {
+                    b.HasOne("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreApplication<Guid>", "Application")
+                        .WithMany("Authorizations")
+                        .HasForeignKey("ApplicationId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.Navigation("Application");
+                });
+
+            modelBuilder.Entity("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreToken<Guid>", b =>
+                {
+                    b.HasOne("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreApplication<Guid>", "Application")
+                        .WithMany("Tokens")
+                        .HasForeignKey("ApplicationId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreAuthorization<Guid>", "Authorization")
+                        .WithMany("Tokens")
+                        .HasForeignKey("AuthorizationId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.Navigation("Application");
+
+                    b.Navigation("Authorization");
+                });
+
+            modelBuilder.Entity("Mazad.Infrastructure.Identity.ApplicationUser", b =>
+                {
+                    b.Navigation("Profile");
+                });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/src/Mazad.WebApi/Endpoints/Categories/CategoriesEndpoints.cs
+++ b/src/Mazad.WebApi/Endpoints/Categories/CategoriesEndpoints.cs
@@ -1,0 +1,57 @@
+using Mazad.Application.Categories.Commands;
+using Mazad.Application.Categories.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Mazad.WebApi.Endpoints.Categories;
+
+public static class CategoriesEndpoints
+{
+    public static RouteGroupBuilder MapPublicCategoriesEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/v1/categories");
+
+        group.MapGet("/", async ([FromServices] IMediator mediator) =>
+        {
+            var result = await mediator.Send(new GetCategoriesTreeQuery());
+            return Results.Ok(result);
+        });
+
+        group.MapGet("/{id:guid}", async ([FromServices] IMediator mediator, Guid id) =>
+        {
+            var result = await mediator.Send(new GetCategoryByIdQuery(id));
+            return Results.Ok(result);
+        });
+
+        return group;
+    }
+
+    public static RouteGroupBuilder MapAdminCategoriesEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/v1/admin/categories")
+            .RequireAuthorization("Scope:mazad.admin");
+
+        group.MapPost("/", async ([FromServices] IMediator mediator, [FromBody] CreateCategoryRequest request) =>
+        {
+            var result = await mediator.Send(new CreateCategoryCommand(request.ParentId, request.Name, request.Slug, request.AttributesSchema));
+            return Results.Created($"/api/v1/admin/categories/{result.Id}", result);
+        });
+
+        group.MapPut("/{id:guid}", async ([FromServices] IMediator mediator, Guid id, [FromBody] UpdateCategoryRequest request) =>
+        {
+            var result = await mediator.Send(new UpdateCategoryCommand(id, request.Name, request.Slug, request.AttributesSchema));
+            return Results.Ok(result);
+        });
+
+        group.MapDelete("/{id:guid}", async ([FromServices] IMediator mediator, Guid id) =>
+        {
+            await mediator.Send(new DeleteCategoryCommand(id));
+            return Results.NoContent();
+        });
+
+        return group;
+    }
+
+    public record CreateCategoryRequest(Guid? ParentId, string Name, string? Slug, string? AttributesSchema);
+    public record UpdateCategoryRequest(string Name, string? Slug, string? AttributesSchema);
+}

--- a/src/Mazad.WebApi/Endpoints/Listings/AdminListingsEndpoints.cs
+++ b/src/Mazad.WebApi/Endpoints/Listings/AdminListingsEndpoints.cs
@@ -1,0 +1,48 @@
+using System.Security.Claims;
+using Mazad.Application.Listings.Commands.Moderation;
+using Mazad.Application.Listings.Queries.GetAdminListings;
+using Mazad.WebApi.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Mazad.WebApi.Endpoints.Listings;
+
+public static class AdminListingsEndpoints
+{
+    public static RouteGroupBuilder MapAdminListingsEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/v1/admin/listings")
+            .RequireAuthorization("Scope:mazad.admin");
+
+        group.MapGet("/", async ([FromServices] IMediator mediator, [FromQuery] string? q, [FromQuery] Guid? sellerId, [FromQuery] Guid? categoryId, [FromQuery] string? status, [FromQuery] string? sort, [FromQuery] int page = 1, [FromQuery] int pageSize = 20) =>
+        {
+            Mazad.Domain.Enums.ListingStatus? parsedStatus = null;
+            if (!string.IsNullOrWhiteSpace(status) && Enum.TryParse<Mazad.Domain.Enums.ListingStatus>(status, true, out var listingStatus))
+            {
+                parsedStatus = listingStatus;
+            }
+
+            var result = await mediator.Send(new GetAdminListingsQuery(q, sellerId, categoryId, parsedStatus, sort, page, pageSize));
+            return Results.Ok(result);
+        });
+
+        group.MapPost("/{id:guid}/approve", async ([FromServices] IMediator mediator, ClaimsPrincipal user, Guid id, [FromBody] ApproveListingRequest request) =>
+        {
+            var adminId = user.GetUserId();
+            var result = await mediator.Send(new ApproveListingCommand(id, adminId, request.Notes));
+            return Results.Ok(result);
+        });
+
+        group.MapPost("/{id:guid}/reject", async ([FromServices] IMediator mediator, ClaimsPrincipal user, Guid id, [FromBody] RejectListingRequest request) =>
+        {
+            var adminId = user.GetUserId();
+            var result = await mediator.Send(new RejectListingCommand(id, adminId, request.Reason));
+            return Results.Ok(result);
+        });
+
+        return group;
+    }
+
+    public record ApproveListingRequest(string? Notes);
+    public record RejectListingRequest(string Reason);
+}

--- a/src/Mazad.WebApi/Endpoints/Listings/PublicListingsEndpoints.cs
+++ b/src/Mazad.WebApi/Endpoints/Listings/PublicListingsEndpoints.cs
@@ -1,0 +1,64 @@
+using System.Security.Claims;
+using Mazad.Application.Bids.Commands;
+using Mazad.Application.Listings.Queries.GetById;
+using Mazad.Application.Listings.Queries.GetPublicListings;
+using Mazad.Application.Watchlists.Commands;
+using Mazad.Application.Watchlists.Queries;
+using Mazad.WebApi.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Mazad.WebApi.Endpoints.Listings;
+
+public static class PublicListingsEndpoints
+{
+    public static RouteGroupBuilder MapPublicListingsEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/v1/listings");
+
+        group.MapGet("/", async ([FromServices] IMediator mediator, [FromQuery] string? q, [FromQuery] Guid? categoryId, [FromQuery] string? type, [FromQuery] string? sort, [FromQuery] int page = 1, [FromQuery] int pageSize = 20) =>
+        {
+            var listingType = Enum.TryParse<Mazad.Domain.Enums.ListingType>(type, true, out var parsed) ? parsed : null;
+            var result = await mediator.Send(new GetPublicListingsQuery(q, categoryId, listingType, sort, page, pageSize));
+            return Results.Ok(result);
+        });
+
+        group.MapGet("/{id:guid}", async ([FromServices] IMediator mediator, Guid id) =>
+        {
+            var result = await mediator.Send(new GetListingByIdQuery(id));
+            return Results.Ok(result);
+        });
+
+        group.MapPost("/{id:guid}/bids", async ([FromServices] IMediator mediator, ClaimsPrincipal user, Guid id, [FromBody] PlaceBidRequest request) =>
+        {
+            var bidderId = user.GetUserId();
+            var bidId = await mediator.Send(new PlaceBidCommand(id, bidderId, request.Amount));
+            return Results.Created($"/api/v1/bids/{bidId}", new { id = bidId });
+        }).RequireAuthorization("Scope:mazad.bidder");
+
+        group.MapGet("/watchlist", async ([FromServices] IMediator mediator, ClaimsPrincipal user, [FromQuery] int page = 1, [FromQuery] int pageSize = 20) =>
+        {
+            var userId = user.GetUserId();
+            var result = await mediator.Send(new GetMyWatchlistQuery(userId, page, pageSize));
+            return Results.Ok(result);
+        }).RequireAuthorization("Scope:mazad.bidder");
+
+        group.MapPost("/{id:guid}/watch", async ([FromServices] IMediator mediator, ClaimsPrincipal user, Guid id) =>
+        {
+            var userId = user.GetUserId();
+            await mediator.Send(new AddToWatchlistCommand(userId, id));
+            return Results.NoContent();
+        }).RequireAuthorization("Scope:mazad.bidder");
+
+        group.MapDelete("/{id:guid}/watch", async ([FromServices] IMediator mediator, ClaimsPrincipal user, Guid id) =>
+        {
+            var userId = user.GetUserId();
+            await mediator.Send(new RemoveFromWatchlistCommand(userId, id));
+            return Results.NoContent();
+        }).RequireAuthorization("Scope:mazad.bidder");
+
+        return group;
+    }
+
+    public record PlaceBidRequest(decimal Amount);
+}

--- a/src/Mazad.WebApi/Endpoints/Listings/SellerListingsEndpoints.cs
+++ b/src/Mazad.WebApi/Endpoints/Listings/SellerListingsEndpoints.cs
@@ -1,0 +1,65 @@
+using System.Security.Claims;
+using Mazad.Application.Listings.Commands.Create;
+using Mazad.Application.Listings.Commands.Submit;
+using Mazad.Application.Listings.Commands.UpdateStatus;
+using Mazad.Application.Listings.Queries.GetSellerListings;
+using Mazad.WebApi.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Mazad.WebApi.Endpoints.Listings;
+
+public static class SellerListingsEndpoints
+{
+    public static RouteGroupBuilder MapSellerListingsEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/v1/seller/listings")
+            .RequireAuthorization("Scope:mazad.seller");
+
+        group.MapGet("/", async ([FromServices] IMediator mediator, ClaimsPrincipal user, [FromQuery] int page = 1, [FromQuery] int pageSize = 20) =>
+        {
+            var sellerId = user.GetUserId();
+            var result = await mediator.Send(new GetSellerListingsQuery(sellerId, page, pageSize));
+            return Results.Ok(result);
+        });
+
+        group.MapPost("/", async ([FromServices] IMediator mediator, ClaimsPrincipal user, [FromBody] CreateListingCommand command) =>
+        {
+            var sellerId = user.GetUserId();
+            var result = await mediator.Send(command with { SellerId = sellerId });
+            return Results.Created($"/api/v1/seller/listings/{result.Id}", result);
+        });
+
+        group.MapPost("/{id:guid}/submit", async ([FromServices] IMediator mediator, ClaimsPrincipal user, Guid id) =>
+        {
+            var sellerId = user.GetUserId();
+            var result = await mediator.Send(new SubmitListingCommand(id, sellerId));
+            return Results.Ok(result);
+        });
+
+        group.MapPost("/{id:guid}/pause", async ([FromServices] IMediator mediator, ClaimsPrincipal user, Guid id) =>
+        {
+            var sellerId = user.GetUserId();
+            var result = await mediator.Send(new UpdateListingStatusCommand(id, sellerId, Mazad.Domain.Enums.ListingStatus.Paused));
+            return Results.Ok(result);
+        });
+
+        group.MapPost("/{id:guid}/resume", async ([FromServices] IMediator mediator, ClaimsPrincipal user, Guid id) =>
+        {
+            var sellerId = user.GetUserId();
+            var result = await mediator.Send(new UpdateListingStatusCommand(id, sellerId, Mazad.Domain.Enums.ListingStatus.Active));
+            return Results.Ok(result);
+        });
+
+        group.MapPost("/{id:guid}/cancel", async ([FromServices] IMediator mediator, ClaimsPrincipal user, Guid id, [FromBody] CancelListingRequest request) =>
+        {
+            var sellerId = user.GetUserId();
+            var result = await mediator.Send(new UpdateListingStatusCommand(id, sellerId, Mazad.Domain.Enums.ListingStatus.Cancelled, request.Reason));
+            return Results.Ok(result);
+        });
+
+        return group;
+    }
+
+    public record CancelListingRequest(string? Reason);
+}

--- a/src/Mazad.WebApi/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Mazad.WebApi/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,12 @@
+using System.Security.Claims;
+
+namespace Mazad.WebApi.Extensions;
+
+public static class ClaimsPrincipalExtensions
+{
+    public static Guid GetUserId(this ClaimsPrincipal principal)
+    {
+        var id = principal.FindFirstValue(ClaimTypes.NameIdentifier) ?? principal.FindFirstValue("sub");
+        return Guid.TryParse(id, out var guid) ? guid : Guid.Empty;
+    }
+}

--- a/src/Mazad.WebApi/Mazad.WebApi.csproj
+++ b/src/Mazad.WebApi/Mazad.WebApi.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="4.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mazad.Application\Mazad.Application.csproj" />
+    <ProjectReference Include="..\Mazad.Infrastructure\Mazad.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Mazad.WebApi/Program.cs
+++ b/src/Mazad.WebApi/Program.cs
@@ -1,0 +1,48 @@
+using Mazad.Application.DependencyInjection;
+using Mazad.Infrastructure.DependencyInjection;
+using Mazad.WebApi.Endpoints.Categories;
+using Mazad.WebApi.Endpoints.Listings;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddApplication();
+builder.Services.AddInfrastructure(builder.Configuration);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new() { Title = "Mazad.com API", Version = "v1" });
+});
+
+builder.Services.ConfigureApplicationCookie(options =>
+{
+    options.LoginPath = "/auth/login";
+});
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseDeveloperExceptionPage();
+}
+
+app.UseSwagger();
+app.UseSwaggerUI(options =>
+{
+    options.SwaggerEndpoint("/swagger/v1/swagger.json", "Mazad.com API v1");
+});
+
+app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapGet("/health", () => Results.Ok(new { status = "healthy" }));
+
+app.MapPublicListingsEndpoints();
+app.MapSellerListingsEndpoints();
+app.MapAdminListingsEndpoints();
+app.MapPublicCategoriesEndpoints();
+app.MapAdminCategoriesEndpoints();
+
+app.Run();

--- a/src/Mazad.WebApi/appsettings.json
+++ b/src/Mazad.WebApi/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=MazadDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- add the first Entity Framework Core migration to create identity, domain, CMS, taxonomy, listing, bidding, watchlist, order, and OpenIddict tables with supporting indexes
- capture the new schema in MazadDbContextModelSnapshot to keep future migrations in sync

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2fd340308832eacd63d770360f545