### PR TITLE
Add business logic overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ Mazad.sln                  // Solution file referencing all projects
 - Minimal API endpoints for public, seller, and admin surfaces aligned with the MVP specification (listings, categories, bids, watchlists).
 - Swagger/OpenAPI enabled for interactive exploration and testing.
 
+## Business logic overview
+
+Mazad.com centers on a multi-role auction marketplace. The core business rules are captured in the application layer as MediatR
+handlers and enforced through request validators and policies:
+
+- **Roles & scopes:** Admin, Seller, Bidder, and CMS users are authenticated through OpenIddict and authorized with scope-based policies to guarantee feature isolation (e.g., `Scope:mazad.seller` for seller endpoints).
+- **Listing lifecycle:** Listings created by sellers progress through `Draft → PendingReview → Approved/Rejected → Active`, and can later transition to `Paused`, `Sold`, `Expired`, or `Cancelled` based on moderation outcomes, time windows, or business triggers.
+- **Bidding rules:** Bids are accepted on active auction listings, the highest valid bid is marked as `Winning`, and outbid participants receive status updates that downstream jobs can process for notifications.
+- **Watchlists & engagement:** Users can follow listings, increasing watch counts and enabling tailored experiences.
+- **Moderation & CMS:** Admins and CMS staff manage catalog taxonomies, content pages, menus, and media assets while maintaining audit trails for compliance.
+
+These rules are reflected in the domain entities (`Listing`, `Bid`, `Watchlist`, `Page`, etc.) and orchestrated via CQRS commands/queries that encapsulate the marketplace workflows.
+
 ## Getting started
 
 1. Update the connection string in `src/Mazad.WebApi/appsettings.json` to point to your SQL Server instance.


### PR DESCRIPTION
## Summary
- add a dedicated business logic overview section to the README
- outline role-based access, listing lifecycle, bidding rules, engagement, and moderation responsibilities

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f476f18698832ead7c06d087ca9c8d